### PR TITLE
Fix/null values in processors

### DIFF
--- a/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
+++ b/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
@@ -71,12 +71,12 @@ public class DocxStamper<T> {
         commentProcessorRegistry = new CommentProcessorRegistry(placeholderReplacer);
         commentProcessorRegistry.setExpressionResolver(expressionResolver);
         commentProcessorRegistry.setFailOnInvalidExpression(config.isFailOnUnresolvedExpression());
-        commentProcessorRegistry.registerCommentProcessor(IRepeatProcessor.class, new RepeatProcessor(typeResolverRegistry, expressionResolver));
-        commentProcessorRegistry.registerCommentProcessor(IParagraphRepeatProcessor.class, new ParagraphRepeatProcessor(typeResolverRegistry, expressionResolver));
+        commentProcessorRegistry.registerCommentProcessor(IRepeatProcessor.class, new RepeatProcessor(typeResolverRegistry, expressionResolver, config));
+        commentProcessorRegistry.registerCommentProcessor(IParagraphRepeatProcessor.class, new ParagraphRepeatProcessor(typeResolverRegistry, expressionResolver, config));
         commentProcessorRegistry.registerCommentProcessor(IRepeatDocPartProcessor.class, new RepeatDocPartProcessor(config));
-        commentProcessorRegistry.registerCommentProcessor(IDisplayIfProcessor.class, new DisplayIfProcessor());
+        commentProcessorRegistry.registerCommentProcessor(IDisplayIfProcessor.class, new DisplayIfProcessor(config));
         commentProcessorRegistry.registerCommentProcessor(IReplaceWithProcessor.class,
-                new ReplaceWithProcessor());
+                new ReplaceWithProcessor(config));
         for (Map.Entry<Class<?>, ICommentProcessor> entry : config.getCommentProcessors().entrySet()) {
             commentProcessorRegistry.registerCommentProcessor(entry.getKey(), entry.getValue());
         }

--- a/src/main/java/org/wickedsource/docxstamper/processor/displayif/DisplayIfProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/displayif/DisplayIfProcessor.java
@@ -1,6 +1,7 @@
 package org.wickedsource.docxstamper.processor.displayif;
 
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
+import org.wickedsource.docxstamper.DocxStamperConfiguration;
 import org.wickedsource.docxstamper.api.coordinates.ParagraphCoordinates;
 import org.wickedsource.docxstamper.api.coordinates.TableCoordinates;
 import org.wickedsource.docxstamper.api.coordinates.TableRowCoordinates;
@@ -13,11 +14,16 @@ import java.util.List;
 
 public class DisplayIfProcessor extends BaseCommentProcessor implements IDisplayIfProcessor {
 
+    private final DocxStamperConfiguration config;
     private List<ParagraphCoordinates> paragraphsToBeRemoved = new ArrayList<>();
 
     private List<TableCoordinates> tablesToBeRemoved = new ArrayList<>();
 
     private List<TableRowCoordinates> tableRowsToBeRemoved = new ArrayList<>();
+
+    public DisplayIfProcessor(DocxStamperConfiguration config) {
+        this.config = config;
+    }
 
     @Override
     public void commitChanges(WordprocessingMLPackage document) {

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/ParagraphRepeatProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/ParagraphRepeatProcessor.java
@@ -14,10 +14,7 @@ import org.wickedsource.docxstamper.replace.PlaceholderReplacer;
 import org.wickedsource.docxstamper.util.CommentUtil;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class ParagraphRepeatProcessor extends BaseCommentProcessor implements IParagraphRepeatProcessor {
 
@@ -37,6 +34,10 @@ public class ParagraphRepeatProcessor extends BaseCommentProcessor implements IP
 
     @Override
     public void repeatParagraph(List<Object> objects) {
+        if (objects == null) {
+            objects = Collections.emptyList();
+        }
+
         ParagraphCoordinates paragraphCoordinates = getCurrentParagraphCoordinates();
 
         P paragraph = paragraphCoordinates.getParagraph();
@@ -58,14 +59,12 @@ public class ParagraphRepeatProcessor extends BaseCommentProcessor implements IP
 
             List<P> paragraphsToAdd = new ArrayList<>();
 
-            if (expressionContexts != null) {
-                for (final Object expressionContext : expressionContexts) {
-                    for (P paragraphToClone : paragraphsToRepeat.paragraphs) {
-                        P pClone = XmlUtils.deepCopy(paragraphToClone);
-                        placeholderReplacer.resolveExpressionsForParagraph(pClone, expressionContext, document);
+            for (final Object expressionContext : expressionContexts) {
+                for (P paragraphToClone : paragraphsToRepeat.paragraphs) {
+                    P pClone = XmlUtils.deepCopy(paragraphToClone);
+                    placeholderReplacer.resolveExpressionsForParagraph(pClone, expressionContext, document);
 
-                        paragraphsToAdd.add(pClone);
-                    }
+                    paragraphsToAdd.add(pClone);
                 }
             }
 

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -17,10 +17,7 @@ import org.wickedsource.docxstamper.util.RunUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRepeatDocPartProcessor {
 
@@ -41,6 +38,10 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
 
     @Override
     public void repeatDocPart(List<Object> contexts) {
+        if (contexts == null) {
+            contexts = Collections.emptyList();
+        }
+
         CommentWrapper currentCommentWrapper = getCurrentCommentWrapper();
         ContentAccessor gcp = findGreatestCommonParent(
                 currentCommentWrapper.getCommentRangeEnd().getParent(),

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatProcessor.java
@@ -15,6 +15,7 @@ import org.wickedsource.docxstamper.util.CommentUtil;
 import org.wickedsource.docxstamper.util.walk.BaseDocumentWalker;
 import org.wickedsource.docxstamper.util.walk.DocumentWalker;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,10 @@ public class RepeatProcessor extends BaseCommentProcessor implements IRepeatProc
 
     @Override
     public void repeatTableRow(List<Object> objects) {
+        if (objects == null) {
+            objects = Collections.emptyList();
+        }
+
         ParagraphCoordinates pCoords = getCurrentParagraphCoordinates();
         if (pCoords.getParentTableCellCoordinates() == null ||
                 pCoords.getParentTableCellCoordinates().getParentTableRowCoordinates() == null) {

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatProcessor.java
@@ -4,6 +4,7 @@ import org.docx4j.XmlUtils;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.P;
 import org.docx4j.wml.Tr;
+import org.wickedsource.docxstamper.DocxStamperConfiguration;
 import org.wickedsource.docxstamper.api.coordinates.ParagraphCoordinates;
 import org.wickedsource.docxstamper.api.coordinates.TableRowCoordinates;
 import org.wickedsource.docxstamper.api.typeresolver.TypeResolverRegistry;
@@ -15,7 +16,6 @@ import org.wickedsource.docxstamper.util.CommentUtil;
 import org.wickedsource.docxstamper.util.walk.BaseDocumentWalker;
 import org.wickedsource.docxstamper.util.walk.DocumentWalker;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,9 +25,11 @@ public class RepeatProcessor extends BaseCommentProcessor implements IRepeatProc
     private Map<TableRowCoordinates, List<Object>> tableRowsToRepeat = new HashMap<>();
 
     private PlaceholderReplacer<Object> placeholderReplacer;
+    private final DocxStamperConfiguration config;
 
-    public RepeatProcessor(TypeResolverRegistry typeResolverRegistry, ExpressionResolver expressionResolver) {
+    public RepeatProcessor(TypeResolverRegistry typeResolverRegistry, ExpressionResolver expressionResolver, DocxStamperConfiguration config) {
         this.placeholderReplacer = new PlaceholderReplacer<>(typeResolverRegistry);
+        this.config = config;
         this.placeholderReplacer.setExpressionResolver(expressionResolver);
     }
 
@@ -45,28 +47,28 @@ public class RepeatProcessor extends BaseCommentProcessor implements IRepeatProc
         for (TableRowCoordinates rCoords : tableRowsToRepeat.keySet()) {
             List<Object> expressionContexts = tableRowsToRepeat.get(rCoords);
             int index = rCoords.getIndex();
-            for (final Object expressionContext : expressionContexts) {
-                Tr rowClone = XmlUtils.deepCopy(rCoords.getRow());
-                DocumentWalker walker = new BaseDocumentWalker(rowClone) {
-                    @Override
-                    protected void onParagraph(P paragraph) {
-                        placeholderReplacer.resolveExpressionsForParagraph(paragraph, expressionContext, document);
-                    }
-                };
-                walker.walk();
-                rCoords.getParentTableCoordinates().getTable().getContent().add(++index, rowClone);
+
+            if (expressionContexts != null) {
+                for (final Object expressionContext : expressionContexts) {
+                    Tr rowClone = XmlUtils.deepCopy(rCoords.getRow());
+                    DocumentWalker walker = new BaseDocumentWalker(rowClone) {
+                        @Override
+                        protected void onParagraph(P paragraph) {
+                            placeholderReplacer.resolveExpressionsForParagraph(paragraph, expressionContext, document);
+                        }
+                    };
+                    walker.walk();
+                    rCoords.getParentTableCoordinates().getTable().getContent().add(++index, rowClone);
+                }
             }
+
+            // TODO : how to replace null values here ?
             rCoords.getParentTableCoordinates().getTable().getContent().remove(rCoords.getRow());
         }
     }
 
-
     @Override
     public void repeatTableRow(List<Object> objects) {
-        if (objects == null) {
-            objects = Collections.emptyList();
-        }
-
         ParagraphCoordinates pCoords = getCurrentParagraphCoordinates();
         if (pCoords.getParentTableCellCoordinates() == null ||
                 pCoords.getParentTableCellCoordinates().getParentTableRowCoordinates() == null) {
@@ -75,5 +77,4 @@ public class RepeatProcessor extends BaseCommentProcessor implements IRepeatProc
         tableRowsToRepeat.put(getCurrentParagraphCoordinates().getParentTableCellCoordinates().getParentTableRowCoordinates(), objects);
         CommentUtil.deleteComment(getCurrentCommentWrapper());
     }
-
 }

--- a/src/main/java/org/wickedsource/docxstamper/processor/replaceExpression/ReplaceWithProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/replaceExpression/ReplaceWithProcessor.java
@@ -1,31 +1,43 @@
 package org.wickedsource.docxstamper.processor.replaceExpression;
 
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wickedsource.docxstamper.DocxStamperConfiguration;
 import org.wickedsource.docxstamper.processor.BaseCommentProcessor;
 import org.wickedsource.docxstamper.util.RunUtil;
 
+/**
+ * @deprecated
+ */
+@Deprecated
 public class ReplaceWithProcessor extends BaseCommentProcessor
-		implements IReplaceWithProcessor {
+        implements IReplaceWithProcessor {
 
-	public ReplaceWithProcessor() {
+    private Logger logger = LoggerFactory.getLogger(ReplaceWithProcessor.class);
 
-	}
+    private final DocxStamperConfiguration config;
 
-	@Override
-	public void commitChanges(WordprocessingMLPackage document) {
-	}
+    public ReplaceWithProcessor(DocxStamperConfiguration config) {
+        this.config = config;
+    }
 
-	@Override
-	public void reset() {
-		// nothing to rest
-	}
+    @Override
+    public void commitChanges(WordprocessingMLPackage document) {
+    }
 
-	@Override
-	public void replaceWordWith(String expression) {
-		if (this.getCurrentRunCoordinates() != null) {
-			RunUtil.setText(this.getCurrentRunCoordinates().getRun(), expression);
-		}
+    @Override
+    public void reset() {
+        // nothing to rest
+    }
 
-	}
-
+    @Override
+    public void replaceWordWith(String expression) {
+        logger.warn("replaceWordWith has been deprecated in favor of inplace placeholders (${expression})");
+        if (expression != null && this.getCurrentRunCoordinates() != null) {
+            RunUtil.setText(this.getCurrentRunCoordinates().getRun(), expression);
+        } else if (config.isReplaceNullValues() && config.getNullValuesDefault() != null) {
+            RunUtil.setText(this.getCurrentRunCoordinates().getRun(), config.getNullValuesDefault());
+        }
+    }
 }


### PR DESCRIPTION
By customizing PropertyAccessors used in the SPEL context, we can allow unresolved variables to be replaced by null values so that the comment processors using them would still be called.

This allows removing the corresponding doc parts & comments even if the value is missing or null.

The behavior can be configured globally with new flags.