### PR TITLE
Add multiple entries to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,16 @@
+Tom Hombergs <tom.hombergs@gmail.com>
+
+caring-coder <joseph@verron.pro>
+caring-coder <joseph@verron.pro> <3975735+josephverron@users.noreply.github.com>
+caring-coder <joseph@verron.pro> <joseph.verron@totalenergies.com>
+caring-coder <joseph@verron.pro> <joseph.verron@gmail.com>
+
+ynaciri <ynaciri@gmail.com>
+ynaciri <ynaciri@gmail.com> <youssouf.naciri@external.totalenergies.com>
 ynaciri <ynaciri@gmail.com> <95088722+AL1047088@users.noreply.github.com>
+
+crivera <chris.rivera@taxfyle.com> <crivera@10.0.0.25>
+crivera <chris.rivera@taxfyle.com> <imbaroxxor@gmail.com>
+crivera <chris.rivera@taxfyle.com> <crivera@devconone.org>
+
+Mario Siegenthaler <m@riosiegenthaler.ch> <mario.siegenthaler@linkyard.ch>


### PR DESCRIPTION
Multiple email addresses have been associated with their corresponding users in the .mailmap file. This change will help in attributing commits accurately and managing contributors' identifiers more efficiently.