### PR TITLE
Update status badges in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,10 @@
+:github: https://github.com/verronpro/docx-stamper/
 :repo: https://github.com/verronpro/docx-stamper/tree/master
 
 = docx-stamper
 
-image:https://github.com/verronpro/docx-stamper/actions/workflows/maven.yml/badge.svg[Build Status,link=https://github.com/verronpro/docx-stamper/actions/workflows/integrate-ubuntu.yml] image:https://github.com/verronpro/docx-stamper/actions/workflows/maven.yml/badge.svg[Build Status,link=https://github.com/verronpro/docx-stamper/actions/workflows/integrate-windows.yml]
+image:{github}/actions/workflows/integrate-ubuntu.yml/badge.svg[Build Status,link={github}/actions/workflows/integrate-ubuntu.yml]
+image:{github}/actions/workflows/integrate-windows.yml/badge.svg[Build Status,link={github}/actions/workflows/integrate-windows.yml]
 
 docx-stamper is a Java template engine for docx documents.
 You create a template .docx document with your favorite word processor and feed it to a DocxStamper instance to create a document based on the template at runtime.


### PR DESCRIPTION
The display of status badges for the build processes in the README file has been adjusted. The previous direct URLs were replaced by dynamic github references. This allows for a consistent display regardless of the repository's location.