### PR TITLE
Modify Maven commands in GitHub workflow files

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -40,7 +40,7 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - run: mvn -B -ntp verify
+      - run: mvn -B -ntp test
 
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2023.3

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -42,4 +42,4 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - run: mvn -B -ntp verify
+      - run: mvn -B -ntp test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           cat <(echo -e "${{ secrets.GPG_SECRET_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
 
-      - run: mvn -B -ntp deploy -P gpg -Dgpg.passphrase=${{ secrets.GPG_SECRET_PASS }}
+      - run: mvn -B -ntp deploy -P gpg,!mut -Dgpg.passphrase=${{ secrets.GPG_SECRET_PASS }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_NAME }}
           MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASS }}


### PR DESCRIPTION
This commit modifies the Maven commands in the release, integrate, and analyze GitHub workflow files. The changes ensure the proper functioning of the workflows by excluding certain profiles during the deployment process and replacing 'verify' commands with 'test'. These changes aim to improve the performance and stability of the development pipeline.