### PR TITLE
Update javadoc for clarity and consistency

### DIFF
--- a/src/main/java/org/wickedsource/docxstamper/CommentProcessorBuilder.java
+++ b/src/main/java/org/wickedsource/docxstamper/CommentProcessorBuilder.java
@@ -1,19 +1,20 @@
 package org.wickedsource.docxstamper;
 
+import org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor;
 import org.wickedsource.docxstamper.replace.PlaceholderReplacer;
 
 /**
- * Factory interface for creating {@link org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor} instances.
+ * Factory interface for creating {@link ICommentProcessor} instances.
  *
  * @author Joseph Verron
  * @version ${version}
  */
 public interface CommentProcessorBuilder {
     /**
-     * Creates a {@link org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor} instance.
+     * Creates a {@link ICommentProcessor} instance.
      *
      * @param placeholderReplacer the placeholder replacer that should be used by the comment processor.
-     * @return a {@link org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor} instance.
+     * @return a {@link ICommentProcessor} instance.
      */
     Object create(PlaceholderReplacer placeholderReplacer);
 }

--- a/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
+++ b/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
@@ -14,6 +14,7 @@ import org.wickedsource.docxstamper.processor.CommentProcessorRegistry;
 import org.wickedsource.docxstamper.replace.PlaceholderReplacer;
 import org.wickedsource.docxstamper.replace.typeresolver.ObjectResolverRegistry;
 import pro.verron.docxstamper.OpcStamper;
+import pro.verron.docxstamper.StamperFactory;
 import pro.verron.docxstamper.api.ObjectResolver;
 
 import java.io.InputStream;
@@ -38,7 +39,7 @@ public class DocxStamper<T> implements OpcStamper<WordprocessingMLPackage> {
 	/**
 	 * Creates a new DocxStamper with the default configuration.
 	 *
-	 * @deprecated since 1.6.4, use {@link pro.verron.docxstamper.StamperFactory#newDocxStamper()} or {@link pro.verron.docxstamper.StamperFactory#nopreprocessingDocxStamper()} instead.
+	 * @deprecated since 1.6.4, use {@link StamperFactory#newDocxStamper()} or {@link StamperFactory#nopreprocessingDocxStamper()} instead.
 	 */
 	@Deprecated(since = "1.6.4", forRemoval = true)
 	public DocxStamper() {
@@ -160,7 +161,7 @@ public class DocxStamper<T> implements OpcStamper<WordprocessingMLPackage> {
 	 * </ul>
 	 * <p>
 	 * If you need a wider vocabulary of methods available in the comments, you can create your own ICommentProcessor
-	 * and register it via getCommentProcessorRegistry().addCommentProcessor().
+	 * and register it via {@link DocxStamperConfiguration#addCommentProcessor(Class, CommentProcessorBuilder)}.
 	 * </p>
 	 */
 	public void stamp(InputStream template, Object contextRoot, OutputStream out) throws DocxStamperException {
@@ -176,7 +177,8 @@ public class DocxStamper<T> implements OpcStamper<WordprocessingMLPackage> {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * Same as stamp(InputStream, T, OutputStream) except that you may pass in a DOCX4J document as a template instead
+	 * Same as {@link #stamp(InputStream, Object, OutputStream)} except that you
+	 * may pass in a DOCX4J document as a template instead
 	 * of an InputStream.
 	 */
 	@Override

--- a/src/main/java/org/wickedsource/docxstamper/DocxStamperConfiguration.java
+++ b/src/main/java/org/wickedsource/docxstamper/DocxStamperConfiguration.java
@@ -1,6 +1,9 @@
 package org.wickedsource.docxstamper;
 
+import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
+import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.SpelParserConfiguration;
+import org.wickedsource.docxstamper.api.DocxStamperException;
 import org.wickedsource.docxstamper.api.EvaluationContextConfigurer;
 import org.wickedsource.docxstamper.api.preprocessor.PreProcessor;
 import org.wickedsource.docxstamper.api.typeresolver.ITypeResolver;
@@ -22,7 +25,8 @@ import java.util.*;
 import static java.util.stream.Collectors.toMap;
 
 /**
- * The {@code DocxStamperConfiguration} class represents the configuration for the {@code DocxStamper} class.
+ * The {@link DocxStamperConfiguration} class represents the configuration for
+ * the {@link DocxStamper} class.
  * It provides methods to customize the behavior of the stamper.
  */
 public class DocxStamperConfiguration {
@@ -70,8 +74,8 @@ public class DocxStamperConfiguration {
      *
      * @return the {@link Optional} containing the default replacement value,
      * or an empty {@link Optional} if no default replacement value is found
-     * @deprecated This method is deprecated since version 1.6.7.
-     * You shouldn't have to use it, it was a crutch use for inner workinf of
+     * @deprecated This method's been deprecated since version 1.6.7.
+     * You shouldn't have to use it, it was a crutch use for inner working of
      * docx-stamper
      */
     @Deprecated(since = "1.6.7")
@@ -93,11 +97,11 @@ public class DocxStamperConfiguration {
     }
 
     /**
-     * If set to true, stamper will throw an {@link org.wickedsource.docxstamper.api.DocxStamperException}
+     * If set to true, stamper will throw an {@link DocxStamperException}
      * if a variable expression or processor expression within the document or within the comments is encountered that cannot be resolved. Is set to true by default.
      *
      * @param failOnUnresolvedExpression a boolean
-     * @return a {@link org.wickedsource.docxstamper.DocxStamperConfiguration} object
+     * @return a {@link DocxStamperConfiguration} object
      */
     public DocxStamperConfiguration setFailOnUnresolvedExpression(boolean failOnUnresolvedExpression) {
         this.failOnUnresolvedExpression = failOnUnresolvedExpression;
@@ -147,7 +151,7 @@ public class DocxStamperConfiguration {
      * Indicates the default value to use for expressions that doesn't resolve.
      *
      * @param unresolvedExpressionsDefaultValue value to use instead for expression that doesn't resolve
-     * @return a {@link org.wickedsource.docxstamper.DocxStamperConfiguration} object
+     * @return a {@link DocxStamperConfiguration} object
      * @see DocxStamperConfiguration#replaceUnresolvedExpressions
      */
     public DocxStamperConfiguration unresolvedExpressionsDefaultValue(String unresolvedExpressionsDefaultValue) {
@@ -156,10 +160,10 @@ public class DocxStamperConfiguration {
     }
 
     /**
-     * Indicates if expressions that doesn't resolve should be replaced by a default value.
+     * Indicates if a default value should replace expressions that don't resolve.
      *
      * @param replaceUnresolvedExpressions true to replace null value expression with resolved value (which is null), false to leave the expression as is
-     * @return a {@link org.wickedsource.docxstamper.DocxStamperConfiguration} object
+     * @return a {@link DocxStamperConfiguration} object
      */
     public DocxStamperConfiguration replaceUnresolvedExpressions(boolean replaceUnresolvedExpressions) {
         this.replaceUnresolvedExpressions = replaceUnresolvedExpressions;
@@ -167,11 +171,11 @@ public class DocxStamperConfiguration {
     }
 
     /**
-     * If an error is caught while evaluating an expression the expression will be replaced with an empty string instead
+     * If an error is caught while evaluating an expression, the expression will be replaced with an empty string instead
      * of leaving the original expression in the document.
      *
      * @param leaveEmpty true to replace expressions with empty string when an error is caught while evaluating
-     * @return a {@link org.wickedsource.docxstamper.DocxStamperConfiguration} object
+     * @return a {@link DocxStamperConfiguration} object
      */
     public DocxStamperConfiguration leaveEmptyOnExpressionError(boolean leaveEmpty) {
         this.leaveEmptyOnExpressionError = leaveEmpty;
@@ -180,7 +184,8 @@ public class DocxStamperConfiguration {
 
     /**
      * <p>
-     * Registers the given ITypeResolver for the given class. The registered ITypeResolver's resolve() method will only
+     * Registers the given {@link ITypeResolver} for the given class. The
+     * registered {@link ITypeResolver#resolve(WordprocessingMLPackage, Object)} method will only
      * be called with objects of the specified class.
      * </p>
      * <p>
@@ -191,7 +196,7 @@ public class DocxStamperConfiguration {
      * @param resolvedType the class whose objects are to be passed to the given ITypeResolver.
      * @param resolver     the resolver to resolve objects of the given type.
      * @param <T>          the type resolved by the ITypeResolver.
-     * @return a {@link org.wickedsource.docxstamper.DocxStamperConfiguration} object
+     * @return a {@link DocxStamperConfiguration} object
      * @deprecated This method has been deprecated since version 1.6.7, and
      * it is scheduled for removal.
      * It's recommended to use the {@link DocxStamperConfiguration#addResolver(ObjectResolver)}
@@ -211,7 +216,7 @@ public class DocxStamperConfiguration {
      * @param interfaceClass the interface whose methods should be exposed in the expression language.
      * @param implementation the implementation that should be called to evaluate invocations of the interface methods
      *                       within the expression language. Must implement the interface above.
-     * @return a {@link org.wickedsource.docxstamper.DocxStamperConfiguration} object
+     * @return a {@link DocxStamperConfiguration} object
      */
     public DocxStamperConfiguration exposeInterfaceToExpressionLanguage(
             Class<?> interfaceClass, Object implementation
@@ -226,7 +231,7 @@ public class DocxStamperConfiguration {
      *
      * @param interfaceClass          the Interface which is implemented by the commentProcessor.
      * @param commentProcessorFactory the commentProcessor factory generating the specified interface.
-     * @return a {@link org.wickedsource.docxstamper.DocxStamperConfiguration} object
+     * @return a {@link DocxStamperConfiguration} object
      */
     public DocxStamperConfiguration addCommentProcessor(
             Class<?> interfaceClass,
@@ -278,7 +283,7 @@ public class DocxStamperConfiguration {
     /**
      * <p>Getter for the field <code>unresolvedExpressionsDefaultValue</code>.</p>
      *
-     * @return a {@link java.lang.String} object
+     * @return a {@link String} object
      */
     public String getUnresolvedExpressionsDefaultValue() {
         return unresolvedExpressionsDefaultValue;
@@ -287,7 +292,7 @@ public class DocxStamperConfiguration {
     /**
      * <p>Getter for the field <code>lineBreakPlaceholder</code>.</p>
      *
-     * @return a {@link java.lang.String} object
+     * @return a {@link String} object
      */
     public String getLineBreakPlaceholder() {
         return lineBreakPlaceholder;
@@ -309,19 +314,19 @@ public class DocxStamperConfiguration {
     /**
      * <p>Getter for the field <code>evaluationContextConfigurer</code>.</p>
      *
-     * @return a {@link org.wickedsource.docxstamper.api.EvaluationContextConfigurer} object
+     * @return a {@link EvaluationContextConfigurer} object
      */
     public EvaluationContextConfigurer getEvaluationContextConfigurer() {
         return evaluationContextConfigurer;
     }
 
     /**
-     * Provides an {@link org.wickedsource.docxstamper.api.EvaluationContextConfigurer} which may change the configuration of a Spring
-     * {@link org.springframework.expression.EvaluationContext} which is used for evaluating expressions
+     * Provides an {@link EvaluationContextConfigurer} which may change the configuration of a Spring
+     * {@link EvaluationContext} which is used for evaluating expressions
      * in comments and text.
      *
      * @param evaluationContextConfigurer the configurer to use.
-     * @return a {@link org.wickedsource.docxstamper.DocxStamperConfiguration} object
+     * @return a {@link DocxStamperConfiguration} object
      */
     public DocxStamperConfiguration setEvaluationContextConfigurer(
             EvaluationContextConfigurer evaluationContextConfigurer
@@ -333,20 +338,20 @@ public class DocxStamperConfiguration {
     /**
      * <p>Getter for the field <code>spelParserConfiguration</code>.</p>
      *
-     * @return a {@link org.springframework.expression.spel.SpelParserConfiguration} object
+     * @return a {@link SpelParserConfiguration} object
      */
     public SpelParserConfiguration getSpelParserConfiguration() {
         return spelParserConfiguration;
     }
 
     /**
-     * Sets the {@link org.springframework.expression.spel.SpelParserConfiguration} to use for expression parsing.
+     * Sets the {@link SpelParserConfiguration} to use for expression parsing.
      * <p>
      * Note that this configuration will be used for all expressions in the document, including expressions in comments!
      * </p>
      *
      * @param spelParserConfiguration the configuration to use.
-     * @return a {@link org.wickedsource.docxstamper.DocxStamperConfiguration} object
+     * @return a {@link DocxStamperConfiguration} object
      */
     public DocxStamperConfiguration setSpelParserConfiguration(
             SpelParserConfiguration spelParserConfiguration
@@ -358,7 +363,7 @@ public class DocxStamperConfiguration {
     /**
      * <p>Getter for the field <code>expressionFunctions</code>.</p>
      *
-     * @return a {@link java.util.Map} object
+     * @return a {@link Map} object
      */
     public Map<Class<?>, Object> getExpressionFunctions() {
         return expressionFunctions;
@@ -368,7 +373,7 @@ public class DocxStamperConfiguration {
      * Retrieves the map of type resolvers.
      *
      * @return the map of type resolvers
-     * @deprecated This method is deprecated since version 1.6.7
+     * @deprecated This method's been deprecated since version 1.6.7
      */
     @Deprecated(since = "1.6.7", forRemoval = true)
     public Map<Class<?>, ITypeResolver<?>> getTypeResolvers() {
@@ -385,8 +390,8 @@ public class DocxStamperConfiguration {
      * {@link ITypeResolver}, and returns the first one found. If no type resolver is found, null is returned.
      *
      * @return the default type resolver, or null if not found
-     * @deprecated This method is deprecated since version 1.6.7 and is scheduled for removal.
-     * You should not have to use it, it was a clutch for previosu version of
+     * @deprecated This method's been deprecated since version 1.6.7 and is scheduled for removal.
+     * You should not have to use it, it was a clutch for previous version of
      * docx-stamper.
      */
     @Deprecated(since = "1.6.7", forRemoval = true)
@@ -422,7 +427,7 @@ public class DocxStamperConfiguration {
     /**
      * <p>Getter for the field <code>commentProcessors</code>.</p>
      *
-     * @return a {@link java.util.Map} object
+     * @return a {@link Map} object
      */
     public Map<Class<?>, CommentProcessorBuilder> getCommentProcessors() {
         return commentProcessors;
@@ -432,7 +437,7 @@ public class DocxStamperConfiguration {
      * Gets the flag indicating whether null values should be replaced.
      *
      * @return {@code true} if null values should be replaced, {@code false} otherwise.
-     * @deprecated This method is deprecated since version 1.6.7 and will be removed in a future release.
+     * @deprecated This method's been deprecated since version 1.6.7 and will be removed in a future release.
      * You shouldn't have to use it, it was a clutch for
      * docx-stamper workings.
      */
@@ -456,7 +461,7 @@ public class DocxStamperConfiguration {
     /**
      * <p>Getter for the field <code>preprocessors</code>.</p>
      *
-     * @return a {@link java.util.List} object
+     * @return a {@link List} object
      */
     public List<PreProcessor> getPreprocessors() {
         return preprocessors;

--- a/src/main/java/org/wickedsource/docxstamper/api/EvaluationContextConfigurer.java
+++ b/src/main/java/org/wickedsource/docxstamper/api/EvaluationContextConfigurer.java
@@ -1,10 +1,13 @@
 package org.wickedsource.docxstamper.api;
 
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.MethodResolver;
+import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /**
- * Allows for custom configuration of a spring expression language {@link org.springframework.expression.EvaluationContext}.
- * This can  for example be used to add custom {@link org.springframework.expression.PropertyAccessor}s and {@link org.springframework.expression.MethodResolver}s.
+ * Allows for custom configuration of a spring expression language {@link EvaluationContext}.
+ * This can, for example, be used to add custom {@link PropertyAccessor}s and {@link MethodResolver}s.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -13,7 +16,7 @@ public interface EvaluationContextConfigurer {
     /**
      * Configure the context before it's used by docxstamper.
      *
-     * @param context the spel eval context, not null
+     * @param context the SPEL eval context, not null
      */
     void configureEvaluationContext(StandardEvaluationContext context);
 }

--- a/src/main/java/org/wickedsource/docxstamper/api/commentprocessor/ICommentProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/api/commentprocessor/ICommentProcessor.java
@@ -38,7 +38,7 @@ public interface ICommentProcessor {
 	/**
 	 * This method is called after all comments in the .docx template have been passed to the comment processor.
 	 * All manipulations of the .docx document SHOULD BE done in this method. If certain manipulations are already done
-	 * within in the custom methods of a comment processor, the ongoing iteration over the paragraphs in the document
+	 * within the custom methods of a comment processor, the ongoing iteration over the paragraphs in the document
 	 * may be disturbed.
 	 *
 	 * @param document The Word document that can be manipulated by using the DOCX4J api.
@@ -46,7 +46,7 @@ public interface ICommentProcessor {
 	void commitChanges(WordprocessingMLPackage document);
 
 	/**
-	 * Passes the paragraph that is currently being processed (i.e. the paragraph that is commented in the
+	 * Passes the paragraph that is currently being processed (i.e., the paragraph that is commented in the
 	 * .docx template). This method is always called BEFORE the custom
 	 * methods of the custom comment processor interface
 	 * are called.
@@ -78,7 +78,7 @@ public interface ICommentProcessor {
 	/**
 	 * Passes the processed document, in order to make all linked data
 	 * (images, etc.) available
-	 * to processors that need it (example : repeatDocPart)
+	 * to processors that need it (example: repeatDocPart)
 	 *
 	 * @param document DocX template being processed.
 	 * @deprecated the document is passed to the processor through the commitChange method now,
@@ -89,7 +89,7 @@ public interface ICommentProcessor {
 	void setDocument(WordprocessingMLPackage document);
 
 	/**
-	 * Resets all state in the comment processor so that it can be re-used in another stamping process.
+	 * Resets all states in the comment processor so that it can be re-used in another stamping process.
 	 */
 	void reset();
 }

--- a/src/main/java/org/wickedsource/docxstamper/api/preprocessor/PreProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/api/preprocessor/PreProcessor.java
@@ -1,15 +1,18 @@
 package org.wickedsource.docxstamper.api.preprocessor;
 
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
+import org.wickedsource.docxstamper.DocxStamper;
+import org.wickedsource.docxstamper.preprocessor.MergeSameStyleRuns;
+import org.wickedsource.docxstamper.preprocessor.RemoveProofErrors;
 
 /**
  * The interface for all pre-processors. Pre-processors are called before the
  * document is processed by the DocxStamper. They can be used to manipulate the
  * document before the actual processing takes place.
  *
- * @see org.wickedsource.docxstamper.DocxStamper
- * @see org.wickedsource.docxstamper.preprocessor.MergeSameStyleRuns
- * @see org.wickedsource.docxstamper.preprocessor.RemoveProofErrors
+ * @see DocxStamper
+ * @see MergeSameStyleRuns
+ * @see RemoveProofErrors
  * @author Joseph Verron
  * @version ${version}
  */

--- a/src/main/java/org/wickedsource/docxstamper/api/typeresolver/ITypeResolver.java
+++ b/src/main/java/org/wickedsource/docxstamper/api/typeresolver/ITypeResolver.java
@@ -29,15 +29,17 @@ import pro.verron.docxstamper.api.ObjectResolver;
 @Deprecated(since = "1.6.7", forRemoval = true)
 public interface ITypeResolver<T> {
     /**
-     * This method is called when a placeholder in the .docx template is to replaced by the result of an expression that
+     * This method is called when a placeholder in the .docx template is to
+     * be replaced by the result of an expression that
      * was found in the .docx template. It creates an object of the DOCX4J api that is put in the place of the found
      * expression.
      *
      * @param document         the Word document that can be accessed via the
      *                        DOCX4J api.
      * @param expressionResult the result of an expression. Only objects of classes this type resolver is registered for
-     *                         within the TypeResolverRegistrey are passed into this method.
-     * @return an object of the DOCX4J api (usually of type org.docx4j.wml.R = "run of text") that will be put in the place of an
+     *                         within the TypeResolverRegistry are passed into this method.
+     * @return an object of the DOCX4J api (usually of type {@link R} = "run
+     * of text" that will be put in the place of an
      * expression found in the .docx document.
      */
     R resolve(WordprocessingMLPackage document, T expressionResult);

--- a/src/main/java/org/wickedsource/docxstamper/el/DefaultEvaluationContextConfigurer.java
+++ b/src/main/java/org/wickedsource/docxstamper/el/DefaultEvaluationContextConfigurer.java
@@ -11,8 +11,8 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * {@link org.wickedsource.docxstamper.api.EvaluationContextConfigurer} that has a better default security,
- * especially doesn't allow Especially known injections.
+ * {@link EvaluationContextConfigurer} that has better default security,
+ * especially doesn't allow especially known injections.
  *
  * @author Joseph Verron
  * @version ${version}

--- a/src/main/java/org/wickedsource/docxstamper/el/ExpressionResolver.java
+++ b/src/main/java/org/wickedsource/docxstamper/el/ExpressionResolver.java
@@ -22,7 +22,7 @@ public class ExpressionResolver {
      * Creates a new ExpressionResolver with the given SpEL parser configuration.
      *
      * @param spelParserConfiguration   the configuration for the SpEL parser.
-     * @param standardEvaluationContext a {@link org.springframework.expression.spel.support.StandardEvaluationContext} object
+     * @param standardEvaluationContext a {@link StandardEvaluationContext} object
      */
     public ExpressionResolver(
             StandardEvaluationContext standardEvaluationContext,

--- a/src/main/java/org/wickedsource/docxstamper/el/ExpressionUtil.java
+++ b/src/main/java/org/wickedsource/docxstamper/el/ExpressionUtil.java
@@ -25,7 +25,8 @@ public class ExpressionUtil {
 	}
 
 	/**
-	 * Finds all variable expressions in a text and returns them as list. Example expression: "${myObject.property}".
+	 * Finds all variable expressions in a text and returns them as a list.
+	 * Example expression: "${myObject.property}".
 	 *
 	 * @param text the text to find expressions in.
 	 * @return a list of expressions (including the starting "${" and trailing "}").
@@ -49,7 +50,8 @@ public class ExpressionUtil {
 	}
 
 	/**
-	 * Finds all processor expressions in a text and returns them as list. Example expression: "#{myObject.property}".
+	 * Finds all processor expressions in a text and returns them as a list.
+	 * Example expression: "#{myObject.property}".
 	 *
 	 * @param text the text to find expressions in.
 	 * @return a list of expressions (including the starting "#{" and trailing "}").

--- a/src/main/java/org/wickedsource/docxstamper/el/StandardMethodExecutor.java
+++ b/src/main/java/org/wickedsource/docxstamper/el/StandardMethodExecutor.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
 
 /**
  * This class is a wrapper around a method call which can be executed by the Spring Expression Language.
- * It is used by the {@link org.wickedsource.docxstamper.el.ExpressionResolver} to evaluate method calls.
+ * It is used by the {@link ExpressionResolver} to evaluate method calls.
  *
  * @author Joseph Verron
  * @version ${version}

--- a/src/main/java/org/wickedsource/docxstamper/preprocessor/MergeSameStyleRuns.java
+++ b/src/main/java/org/wickedsource/docxstamper/preprocessor/MergeSameStyleRuns.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Merges runs with the same style that are next to each other.
+ * Merges same style runs that are next to each other.
  *
  * @author Joseph Verron
  * @version ${version}

--- a/src/main/java/org/wickedsource/docxstamper/preprocessor/RemoveProofErrors.java
+++ b/src/main/java/org/wickedsource/docxstamper/preprocessor/RemoveProofErrors.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Removes all {@link org.docx4j.wml.ProofErr} elements from the document.
+ * Removes all {@link ProofErr} elements from the document.
  *
  * @author Joseph Verron
  * @version ${version}

--- a/src/main/java/org/wickedsource/docxstamper/processor/BaseCommentProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/BaseCommentProcessor.java
@@ -3,6 +3,7 @@ package org.wickedsource.docxstamper.processor;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.P;
 import org.docx4j.wml.R;
+import org.wickedsource.docxstamper.DocxStamper;
 import org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor;
 import org.wickedsource.docxstamper.replace.PlaceholderReplacer;
 import org.wickedsource.docxstamper.util.CommentWrapper;
@@ -10,7 +11,7 @@ import org.wickedsource.docxstamper.util.CommentWrapper;
 import java.util.Objects;
 
 /**
- * Base class for comment processors. The current run and paragraph are set by the {@link org.wickedsource.docxstamper.DocxStamper} class.
+ * Base class for comment processors. The current run and paragraph are set by the {@link DocxStamper} class.
  *
  * @author Joseph Verron
  * @version ${version}

--- a/src/main/java/org/wickedsource/docxstamper/processor/CommentProcessorFactory.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/CommentProcessorFactory.java
@@ -34,8 +34,8 @@ public class CommentProcessorFactory {
 	/**
 	 * Creates a new CommentProcessorFactory with default configuration.
 	 *
-	 * @param pr a {@link org.wickedsource.docxstamper.replace.PlaceholderReplacer} object
-	 * @return a {@link org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor} object
+	 * @param pr a {@link PlaceholderReplacer} object
+	 * @return a {@link ICommentProcessor} object
 	 */
 	public ICommentProcessor repeatParagraph(PlaceholderReplacer pr) {
 		return ParagraphRepeatProcessor.newInstance(pr);
@@ -44,8 +44,8 @@ public class CommentProcessorFactory {
 	/**
 	 * Creates a new CommentProcessorFactory with default configuration.
 	 *
-	 * @param pr a {@link org.wickedsource.docxstamper.replace.PlaceholderReplacer} object
-	 * @return a {@link org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor} object
+	 * @param pr a {@link PlaceholderReplacer} object
+	 * @return a {@link ICommentProcessor} object
 	 */
 	public ICommentProcessor repeatDocPart(PlaceholderReplacer pr) {
 		return RepeatDocPartProcessor.newInstance(pr, getStamper());
@@ -58,8 +58,8 @@ public class CommentProcessorFactory {
 	/**
 	 * Creates a new CommentProcessorFactory with default configuration.
 	 *
-	 * @param pr a {@link org.wickedsource.docxstamper.replace.PlaceholderReplacer} object
-	 * @return a {@link org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor} object
+	 * @param pr a {@link PlaceholderReplacer} object
+	 * @return a {@link ICommentProcessor} object
 	 */
 	public ICommentProcessor repeat(PlaceholderReplacer pr) {
 		return RepeatProcessor.newInstance(pr);
@@ -68,8 +68,8 @@ public class CommentProcessorFactory {
 	/**
 	 * Creates a new CommentProcessorFactory with default configuration.
 	 *
-	 * @param pr a {@link org.wickedsource.docxstamper.replace.PlaceholderReplacer} object
-	 * @return a {@link org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor} object
+	 * @param pr a {@link PlaceholderReplacer} object
+	 * @return a {@link ICommentProcessor} object
 	 */
 	public ICommentProcessor tableResolver(PlaceholderReplacer pr) {
 		return TableResolver.newInstance(pr);
@@ -78,8 +78,8 @@ public class CommentProcessorFactory {
 	/**
 	 * Creates a new CommentProcessorFactory with default configuration.
 	 *
-	 * @param pr a {@link org.wickedsource.docxstamper.replace.PlaceholderReplacer} object
-	 * @return a {@link org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor} object
+	 * @param pr a {@link PlaceholderReplacer} object
+	 * @return a {@link ICommentProcessor} object
 	 */
 	public ICommentProcessor displayIf(PlaceholderReplacer pr) {
 		return DisplayIfProcessor.newInstance(pr);
@@ -88,8 +88,8 @@ public class CommentProcessorFactory {
 	/**
 	 * Creates a new CommentProcessorFactory with default configuration.
 	 *
-	 * @param pr a {@link org.wickedsource.docxstamper.replace.PlaceholderReplacer} object
-	 * @return a {@link org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor} object
+	 * @param pr a {@link PlaceholderReplacer} object
+	 * @return a {@link ICommentProcessor} object
 	 */
 	public ICommentProcessor replaceWith(PlaceholderReplacer pr) {
 		return ReplaceWithProcessor.newInstance(pr);

--- a/src/main/java/org/wickedsource/docxstamper/processor/CommentProcessorRegistry.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/CommentProcessorRegistry.java
@@ -25,10 +25,10 @@ import java.util.*;
 import static org.wickedsource.docxstamper.el.ExpressionUtil.findProcessorExpressions;
 
 /**
- * Allows registration of ICommentProcessor objects. Each registered
+ * Allows registration of {@link ICommentProcessor} objects. Each registered
  * ICommentProcessor must implement an interface which has to be specified at
  * registration time. Provides several getter methods to access the registered
- * ICommentProcessors.
+ * {@link ICommentProcessor}.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -62,8 +62,8 @@ public class CommentProcessorRegistry {
     }
 
     /**
-     * Lets each registered ICommentProcessor have a run on the specified docx
-     * document. At the end of the document the commit method is called for each
+     * Lets each registered ICommentProcessor run on the specified docx
+     * document. At the end of the document, the commit method is called for each
      * ICommentProcessor. The ICommentProcessors are run in the order they were
      * registered.
      *

--- a/src/main/java/org/wickedsource/docxstamper/processor/displayif/DisplayIfProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/displayif/DisplayIfProcessor.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Processor for the {@link org.wickedsource.docxstamper.processor.displayif.IDisplayIfProcessor} comment.
+ * Processor for the {@link IDisplayIfProcessor} comment.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -33,7 +33,7 @@ public class DisplayIfProcessor extends BaseCommentProcessor implements IDisplay
 	/**
 	 * Creates a new DisplayIfProcessor instance.
 	 *
-	 * @param pr the {@link org.wickedsource.docxstamper.replace.PlaceholderReplacer} to use for replacing placeholders.
+	 * @param pr the {@link PlaceholderReplacer} to use for replacing placeholders.
 	 * @return a new DisplayIfProcessor instance.
 	 */
 	public static ICommentProcessor newInstance(PlaceholderReplacer pr) {

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/IRepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/IRepeatDocPartProcessor.java
@@ -17,7 +17,7 @@ public interface IRepeatDocPartProcessor {
      * Within each copy of the row, all expressions are evaluated against one of the objects in the list.
      *
      * @param objects the objects which serve as context root for expressions found in the template table row.
-     * @throws java.lang.Exception if the processing fails.
+     * @throws Exception if the processing fails.
      */
     void repeatDocPart(List<Object> objects) throws Exception;
 }

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -32,8 +32,8 @@ import static java.util.stream.Collectors.toMap;
 import static org.wickedsource.docxstamper.util.DocumentUtil.walkObjectsAndImportImages;
 
 /**
- * This class is responsible for processing the &lt;ds:repeat&gt; tag.
- * It uses the {@link pro.verron.docxstamper.OpcStamper} to stamp the sub document and then
+ * This class is responsible for processing the &lt;ds: repeat&gt; tag.
+ * It uses the {@link OpcStamper} to stamp the sub document and then
  * copies the resulting sub document to the correct position in the
  * main document.
  *

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatProcessor.java
@@ -50,8 +50,8 @@ public class RepeatProcessor extends BaseCommentProcessor implements IRepeatProc
      * Creates a new RepeatProcessor.
      *
      * @param pr       The PlaceholderReplacer to use.
-     * @param document a {@link org.docx4j.openpackaging.packages.WordprocessingMLPackage} object
-     * @param row1     a {@link org.docx4j.wml.Tr} object
+     * @param document a {@link WordprocessingMLPackage} object
+     * @param row1     a {@link Tr} object
      * @return A new RepeatProcessor.
      */
     public static List<Tr> stampEmptyContext(PlaceholderReplacer pr, WordprocessingMLPackage document, Tr row1) {

--- a/src/main/java/org/wickedsource/docxstamper/processor/replaceExpression/ReplaceWithProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/replaceExpression/ReplaceWithProcessor.java
@@ -38,7 +38,7 @@ public class ReplaceWithProcessor
 	 * Creates a new processor that replaces the current run with the result of the expression.
 	 *
 	 * @param pr                   the placeholder replacer to use
-	 * @param nullReplacementValue a {@link java.lang.String} object
+	 * @param nullReplacementValue a {@link String} object
 	 * @return the processor
 	 */
 	public static ICommentProcessor newInstance(PlaceholderReplacer pr, String nullReplacementValue) {

--- a/src/main/java/org/wickedsource/docxstamper/processor/table/StampTable.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/table/StampTable.java
@@ -6,7 +6,7 @@ import java.util.List;
 import static java.util.Collections.singletonList;
 
 /**
- * Represents a table with several columns, a headers line, and several lines of content
+ * Represents a table with several columns, a header line, and several lines of content
  *
  * @author Joseph Verron
  * @version ${version}
@@ -40,16 +40,19 @@ public class StampTable {
     /**
      * <p>empty.</p>
      *
-     * @return a {@link org.wickedsource.docxstamper.processor.table.StampTable} object
+     * @return a {@link StampTable} object
      */
     public static StampTable empty() {
-        return new StampTable(singletonList("placeholder"), singletonList(singletonList("placeholder")));
+        return new StampTable(
+                singletonList("placeholder"),
+                singletonList(singletonList("placeholder"))
+        );
     }
 
     /**
      * <p>headers.</p>
      *
-     * @return a {@link java.util.List} object
+     * @return a {@link List} object
      */
     public List<String> headers() {
         return headers;
@@ -58,7 +61,7 @@ public class StampTable {
     /**
      * <p>records.</p>
      *
-     * @return a {@link java.util.List} object
+     * @return a {@link List} object
      */
     public List<List<String>> records() {
         return records;

--- a/src/main/java/org/wickedsource/docxstamper/processor/table/TableResolver.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/table/TableResolver.java
@@ -33,21 +33,21 @@ public class TableResolver extends BaseCommentProcessor implements ITableResolve
 	}
 
 	/**
-	 * Generate a new {@link org.wickedsource.docxstamper.processor.table.TableResolver} instance
+	 * Generate a new {@link TableResolver} instance
 	 *
-	 * @param pr                   a {@link org.wickedsource.docxstamper.replace.PlaceholderReplacer} instance
+	 * @param pr                   a {@link PlaceholderReplacer} instance
 	 * @param nullReplacementValue in case the value to interpret is <code>null</code>
-	 * @return a new {@link org.wickedsource.docxstamper.processor.table.TableResolver} instance
+	 * @return a new {@link TableResolver} instance
 	 */
 	public static ICommentProcessor newInstance(PlaceholderReplacer pr, String nullReplacementValue) {
 		return new TableResolver(pr, table -> List.of(ParagraphUtil.create(nullReplacementValue)));
 	}
 
 	/**
-	 * Generate a new {@link org.wickedsource.docxstamper.processor.table.TableResolver} instance where value is replaced by an empty list when <code>null</code>
+	 * Generate a new {@link TableResolver} instance where value is replaced by an empty list when <code>null</code>
 	 *
-	 * @param pr a {@link org.wickedsource.docxstamper.replace.PlaceholderReplacer} instance
-	 * @return a new {@link org.wickedsource.docxstamper.processor.table.TableResolver} instance
+	 * @param pr a {@link PlaceholderReplacer} instance
+	 * @return a new {@link TableResolver} instance
 	 */
 	public static ICommentProcessor newInstance(PlaceholderReplacer pr) {
         return new TableResolver(pr, table -> Collections.emptyList());

--- a/src/main/java/org/wickedsource/docxstamper/replace/PlaceholderReplacer.java
+++ b/src/main/java/org/wickedsource/docxstamper/replace/PlaceholderReplacer.java
@@ -21,13 +21,14 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Replaces expressions in a document with the values provided by the {@link org.wickedsource.docxstamper.el.ExpressionResolver}.
+ * Replaces expressions in a document with the values provided by the {@link ExpressionResolver}.
  *
  * @author Joseph Verron
  * @version ${version}
  */
 public class PlaceholderReplacer {
-    private static final Logger log = LoggerFactory.getLogger(PlaceholderReplacer.class);
+    private static final Logger log = LoggerFactory.getLogger(
+            PlaceholderReplacer.class);
     private final ExpressionResolver expressionResolver;
     private final ObjectResolverRegistry resolverRegistry;
     private final boolean failOnUnresolvedExpression;
@@ -39,14 +40,16 @@ public class PlaceholderReplacer {
     /**
      * <p>Constructor for PlaceholderReplacer.</p>
      *
-     * @param resolverRegistry              the registry containing all available type resolvers.
+     * @param resolverRegistry                  the registry containing all available type resolvers.
      * @param expressionResolver                the expression resolver used to resolve expressions in the document.
      * @param failOnUnresolvedExpression        if set to true, an exception is thrown when an expression cannot be
      *                                          resolved.
      * @param replaceUnresolvedExpressions      if set to true, expressions that cannot be resolved are replaced by the
      *                                          value provided in the unresolvedExpressionsDefaultValue parameter.
      * @param unresolvedExpressionsDefaultValue the value to use when replacing unresolved expressions.
-     * @param leaveEmptyOnExpressionError       if set to true, expressions that cannot be resolved are replaced by an
+     * @param leaveEmptyOnExpressionError       if set to true, expressions
+     *                                          that cannot be resolved will
+     *                                          be by replaced by an
      *                                          empty string.
      * @param lineBreakPlaceholder              if set to a non-null value, all occurrences of this placeholder will be
      *                                          replaced with a line break.
@@ -70,17 +73,22 @@ public class PlaceholderReplacer {
     }
 
     /**
-     * Finds expressions in a document and resolves them against the specified context object. The expressions in the
-     * document are then replaced by the resolved values.
+     * Finds expressions in a document and resolves them against the specified context object.
+     * The resolved values will then replace the expressions in the document.
      *
      * @param document          the document in which to replace all expressions.
      * @param expressionContext the context root
      */
-    public void resolveExpressions(final WordprocessingMLPackage document, Object expressionContext) {
+    public void resolveExpressions(
+            final WordprocessingMLPackage document,
+            Object expressionContext
+    ) {
         new BaseCoordinatesWalker() {
             @Override
             protected void onParagraph(P paragraph) {
-                resolveExpressionsForParagraph(paragraph, expressionContext, document);
+                resolveExpressionsForParagraph(paragraph,
+                                               expressionContext,
+                                               document);
             }
         }.walk(document);
     }
@@ -92,12 +100,19 @@ public class PlaceholderReplacer {
      * @param expressionContext the context root
      * @param document          the document in which to replace all expressions.
      */
-    public void resolveExpressionsForParagraph(P p, Object expressionContext, WordprocessingMLPackage document) {
+    public void resolveExpressionsForParagraph(
+            P p,
+            Object expressionContext,
+            WordprocessingMLPackage document
+    ) {
         ParagraphWrapper paragraphWrapper = new ParagraphWrapper(p);
-        List<String> placeholders = ExpressionUtil.findVariableExpressions(paragraphWrapper.getText());
+        List<String> placeholders = ExpressionUtil.findVariableExpressions(
+                paragraphWrapper.getText());
         for (String placeholder : placeholders) {
             try {
-                Object replacement = expressionResolver.resolveExpression(placeholder, expressionContext);
+                Object replacement = expressionResolver.resolveExpression(
+                        placeholder,
+                        expressionContext);
                 R replacementObject = resolverRegistry.resolve(document,
                                                                placeholder,
                                                                replacement);
@@ -105,10 +120,12 @@ public class PlaceholderReplacer {
             } catch (SpelEvaluationException | SpelParseException e) {
                 if (isFailOnUnresolvedExpression()) {
                     String message = "Expression %s could not be resolved against context of type %s"
-                            .formatted(placeholder, expressionContext.getClass());
+                            .formatted(placeholder,
+                                       expressionContext.getClass());
                     throw new DocxStamperException(message, e);
                 } else {
-                    log.warn("Expression {} could not be resolved against context root of type {}. Reason: {}. Set log level to TRACE to view Stacktrace.",
+                    log.warn(
+                            "Expression {} could not be resolved against context root of type {}. Reason: {}. Set log level to TRACE to view Stacktrace.",
                             placeholder,
                             expressionContext.getClass(),
                             e.getMessage());
@@ -116,7 +133,9 @@ public class PlaceholderReplacer {
                     if (leaveEmptyOnExpressionError()) {
                         replace(paragraphWrapper, placeholder, "");
                     } else if (replaceUnresolvedExpressions()) {
-                        replace(paragraphWrapper, placeholder, unresolvedExpressionsDefaultValue());
+                        replace(paragraphWrapper,
+                                placeholder,
+                                unresolvedExpressionsDefaultValue());
                     }
                 }
             }
@@ -126,8 +145,13 @@ public class PlaceholderReplacer {
         }
     }
 
-    private void replace(ParagraphWrapper p, String placeholder, R replacementRun) {
-        p.replace(placeholder, replacementRun == null ? RunUtil.create("") : replacementRun);
+    private void replace(
+            ParagraphWrapper p,
+            String placeholder,
+            R replacementRun
+    ) {
+        p.replace(placeholder,
+                  replacementRun == null ? RunUtil.create("") : replacementRun);
     }
 
     private boolean isFailOnUnresolvedExpression() {
@@ -145,10 +169,17 @@ public class PlaceholderReplacer {
      * @param placeholder       the placeholder to replace.
      * @param replacementObject the object to replace the placeholder with.
      */
-    public void replace(ParagraphWrapper p, String placeholder, String replacementObject) {
+    public void replace(
+            ParagraphWrapper p,
+            String placeholder,
+            String replacementObject
+    ) {
         Optional.ofNullable(replacementObject)
-                .map(replacementStr -> RunUtil.create(replacementStr, p.getParagraph()))
-                .ifPresent(replacementRun -> replace(p, placeholder, replacementRun));
+                .map(replacementStr -> RunUtil.create(replacementStr,
+                                                      p.getParagraph()))
+                .ifPresent(replacementRun -> replace(p,
+                                                     placeholder,
+                                                     replacementRun));
     }
 
     private boolean replaceUnresolvedExpressions() {
@@ -164,9 +195,11 @@ public class PlaceholderReplacer {
     }
 
     private void replaceLineBreaks(ParagraphWrapper paragraphWrapper) {
-        Br lineBreak = Context.getWmlObjectFactory().createBr();
+        Br lineBreak = Context.getWmlObjectFactory()
+                .createBr();
         R run = RunUtil.create(lineBreak);
-        while (paragraphWrapper.getText().contains(lineBreakPlaceholder())) {
+        while (paragraphWrapper.getText()
+                .contains(lineBreakPlaceholder())) {
             replace(paragraphWrapper, lineBreakPlaceholder(), run);
         }
     }

--- a/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/LegacyFallbackResolver.java
+++ b/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/LegacyFallbackResolver.java
@@ -14,7 +14,9 @@ import pro.verron.docxstamper.preset.resolver.Resolvers;
  *
  * @version ${version}
  *
- * @deprecated as of version 1.6.7, use {@link Resolvers#fallback()} instead. LegacyFallbackResolver
+ * @deprecated as of version 1.6.7, use
+ * {@link Resolvers#fallback()} instead.
+ * LegacyFallbackResolver
  * was capable of mapping any object to their String representation.
  * Now, this is more streamlined and manageable using {@link Resolvers#fallback()}.
  */

--- a/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/image/Image.java
+++ b/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/image/Image.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * This class describes an image which will be inserted into document.
+ * This class describes an image which will be inserted into a document.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -21,7 +21,7 @@ public class Image {
      * <p>Constructor for Image.</p>
      *
      * @param in - content of the image as InputStream
-     * @throws java.io.IOException if any.
+     * @throws IOException if any.
      */
     public Image(InputStream in) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -34,7 +34,7 @@ public class Image {
      *
      * @param in - content of the image as InputStream
      * @param maxWidth - max width of the image in twip
-     * @throws java.io.IOException if any.
+     * @throws IOException if any.
      */
     public Image(InputStream in, Integer maxWidth) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/src/main/java/org/wickedsource/docxstamper/util/CommentUtil.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/CommentUtil.java
@@ -7,6 +7,7 @@ import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.PartName;
 import org.docx4j.openpackaging.parts.WordprocessingML.CommentsPart;
 import org.docx4j.wml.*;
+import org.docx4j.wml.Comments.Comment;
 import org.jvnet.jaxb2_commons.ppp.Child;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,7 @@ public class CommentUtil {
      * @param document the document that contains the object.
      * @return Optional of the comment, if found, Optional.empty() otherwise.
      */
-    public static Optional<Comments.Comment> getCommentAround(
+    public static Optional<Comment> getCommentAround(
             R run, WordprocessingMLPackage document
     ) {
         if (run == null) return Optional.empty();
@@ -59,7 +60,7 @@ public class CommentUtil {
         }
     }
 
-    private static Optional<Comments.Comment> getComment(
+    private static Optional<Comment> getComment(
             R run, WordprocessingMLPackage document, ContentAccessor parent
     ) throws Docx4JException {
         CommentRangeStart possibleComment = null;
@@ -98,9 +99,9 @@ public class CommentUtil {
      * @param document the WordprocessingMLPackage document to search for the comment
      * @param id       the ID of the comment to find
      * @return an Optional containing the Comment if found, or an empty Optional if not found
-     * @throws org.docx4j.openpackaging.exceptions.Docx4JException if an error occurs while searching for the comment
+     * @throws Docx4JException if an error occurs while searching for the comment
      */
-    public static Optional<Comments.Comment> findComment(
+    public static Optional<Comment> findComment(
             WordprocessingMLPackage document, BigInteger id
     ) throws Docx4JException {
         var name = new PartName(WORD_COMMENTS_PART_NAME);
@@ -124,7 +125,7 @@ public class CommentUtil {
     public static String getCommentStringFor(
             ContentAccessor object, WordprocessingMLPackage document
     ) {
-        Comments.Comment comment = getCommentFor(object,
+        Comment comment = getCommentFor(object,
                                                  document).orElseThrow();
         return getCommentString(comment);
     }
@@ -137,10 +138,10 @@ public class CommentUtil {
      * @param object   the object whose comment to load.
      * @param document the document in which the object is embedded (needed to load the
      *                 comment from the comments.xml part).
-     * @return the concatenated string of all paragraphs of text within the comment or
-     * null if the specified object is not commented.
+     * @return the concatenated string of all text paragraphs within the
+     * comment or null if the specified object is not commented.
      */
-    public static Optional<Comments.Comment> getCommentFor(
+    public static Optional<Comment> getCommentFor(
             ContentAccessor object, WordprocessingMLPackage document
     ) {
         for (Object contentObject : object.getContent()) {
@@ -166,7 +167,7 @@ public class CommentUtil {
                         e);
             }
 
-            for (Comments.Comment comment : comments.getComment()) {
+            for (Comment comment : comments.getComment()) {
                 if (comment.getId()
                         .equals(id)) {
                     return Optional.of(comment);
@@ -179,10 +180,10 @@ public class CommentUtil {
     /**
      * Returns the string value of the specified comment object.
      *
-     * @param comment a {@link org.docx4j.wml.Comments.Comment} object
-     * @return a {@link java.lang.String} object
+     * @param comment a {@link Comment} object
+     * @return a {@link String} object
      */
-    public static String getCommentString(Comments.Comment comment) {
+    public static String getCommentString(Comment comment) {
         StringBuilder builder = new StringBuilder();
         for (Object commentChildObject : comment.getContent()) {
             if (commentChildObject instanceof P p) {
@@ -195,7 +196,7 @@ public class CommentUtil {
     /**
      * Returns the string value of the specified comment object.
      *
-     * @param comment a {@link org.wickedsource.docxstamper.util.CommentWrapper} object
+     * @param comment a {@link CommentWrapper} object
      */
     public static void deleteComment(CommentWrapper comment) {
         CommentRangeEnd end = comment.getCommentRangeEnd();
@@ -221,8 +222,8 @@ public class CommentUtil {
     /**
      * Returns the string value of the specified comment object.
      *
-     * @param items     a {@link java.util.List} object
-     * @param commentId a {@link java.math.BigInteger} object
+     * @param items     a {@link List} object
+     * @param commentId a {@link BigInteger} object
      */
     public static void deleteCommentFromElement(
             List<Object> items, BigInteger commentId

--- a/src/main/java/org/wickedsource/docxstamper/util/CommentWrapper.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/CommentWrapper.java
@@ -6,6 +6,8 @@ import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.WordprocessingML.CommentsPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.MainDocumentPart;
 import org.docx4j.wml.*;
+import org.docx4j.wml.Comments.Comment;
+import org.docx4j.wml.R.CommentReference;
 import org.jvnet.jaxb2_commons.ppp.Child;
 import org.wickedsource.docxstamper.api.DocxStamperException;
 
@@ -21,12 +23,12 @@ import java.util.stream.Collectors;
 public class CommentWrapper {
 
 	private final Set<CommentWrapper> children = new HashSet<>();
-	private Comments.Comment comment;
+	private Comment comment;
 	private CommentRangeStart commentRangeStart;
 	private CommentRangeEnd commentRangeEnd;
-	private R.CommentReference commentReference;
+	private CommentReference commentReference;
 
-	void setComment(Comments.Comment comment) {
+	void setComment(Comment comment) {
 		this.comment = comment;
 	}
 
@@ -38,7 +40,7 @@ public class CommentWrapper {
 		this.commentRangeEnd = commentRangeEnd;
 	}
 
-	void setCommentReference(R.CommentReference commentReference) {
+	void setCommentReference(CommentReference commentReference) {
 		this.commentReference = commentReference;
 	}
 
@@ -116,7 +118,7 @@ public class CommentWrapper {
 		CommentUtil.deleteCommentFromElement(fakeBody.getContent(), getComment().getId());
 	}
 
-	private void extractedSubComments(List<Comments.Comment> commentList, Set<CommentWrapper> commentWrapperChildren) {
+	private void extractedSubComments(List<Comment> commentList, Set<CommentWrapper> commentWrapperChildren) {
 		Queue<CommentWrapper> q = new ArrayDeque<>(commentWrapperChildren);
 		while (!q.isEmpty()) {
 			CommentWrapper element = q.remove();
@@ -131,7 +133,7 @@ public class CommentWrapper {
 	 *
 	 * @param document the document from which to copy the elements.
 	 * @return a new document containing only the elements between the comment range anchors.
-	 * @throws java.lang.Exception if the subtemplate could not be created.
+	 * @throws Exception if the sub template could not be created.
 	 */
 	public WordprocessingMLPackage getSubTemplate(WordprocessingMLPackage document) throws Exception {
 		List<Object> repeatElements = getRepeatElements();
@@ -162,7 +164,8 @@ public class CommentWrapper {
 
 	/**
 	 * Creates a new document containing only the elements between the comment range anchors.
-	 * If the subtemplate could not be created, a {@link org.wickedsource.docxstamper.api.DocxStamperException} is thrown.
+	 * If the sub template could not be created, a
+	 * {@link DocxStamperException} is thrown.
 	 *
 	 * @param document the document from which to copy the elements.
 	 * @return a new document containing only the elements between the comment range anchors.
@@ -178,7 +181,7 @@ public class CommentWrapper {
 	/**
 	 * <p>Getter for the field <code>commentRangeEnd</code>.</p>
 	 *
-	 * @return a {@link org.docx4j.wml.CommentRangeEnd} object
+	 * @return a {@link CommentRangeEnd} object
 	 */
 	public CommentRangeEnd getCommentRangeEnd() {
 		return commentRangeEnd;
@@ -187,7 +190,7 @@ public class CommentWrapper {
 	/**
 	 * <p>Getter for the field <code>commentRangeStart</code>.</p>
 	 *
-	 * @return a {@link org.docx4j.wml.CommentRangeStart} object
+	 * @return a {@link CommentRangeStart} object
 	 */
 	public CommentRangeStart getCommentRangeStart() {
 		return commentRangeStart;
@@ -196,16 +199,16 @@ public class CommentWrapper {
 	/**
 	 * <p>Getter for the field <code>commentReference</code>.</p>
 	 *
-	 * @return a {@link org.docx4j.wml.R.CommentReference} object
+	 * @return a {@link CommentReference} object
 	 */
-	public R.CommentReference getCommentReference() {
+	public CommentReference getCommentReference() {
 		return commentReference;
 	}
 
 	/**
 	 * <p>Getter for the field <code>children</code>.</p>
 	 *
-	 * @return a {@link java.util.Set} object
+	 * @return a {@link Set} object
 	 */
 	public Set<CommentWrapper> getChildren() {
 		return children;
@@ -214,9 +217,9 @@ public class CommentWrapper {
 	/**
 	 * <p>Getter for the field <code>comment</code>.</p>
 	 *
-	 * @return a {@link org.docx4j.wml.Comments.Comment} object
+	 * @return a {@link Comment} object
 	 */
-	public Comments.Comment getComment() {
+	public Comment getComment() {
 		return comment;
 	}
 }

--- a/src/main/java/org/wickedsource/docxstamper/util/DocumentUtil.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/DocumentUtil.java
@@ -132,7 +132,7 @@ public class DocumentUtil {
 	}
 
 	/**
-	 * Recursively walk through source to find embedded images and import them in the target document.
+	 * Recursively walk through a source to find embedded images and import them in the target document.
 	 *
 	 * @param source source document containing image files.
 	 * @param target target document to add image files to.

--- a/src/main/java/org/wickedsource/docxstamper/util/DocxImageExtractor.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/DocxImageExtractor.java
@@ -88,7 +88,7 @@ public class DocxImageExtractor {
 	}
 
 	/**
-	 * Converts an InputStream to byte array.
+	 * Converts an InputStream to a byte array.
 	 *
 	 * @param size expected size of the byte array.
 	 * @param is   input stream to read data from.
@@ -133,7 +133,7 @@ public class DocxImageExtractor {
 	 * Extract the name of the image from an embedded image run.
 	 *
 	 * @param run run containing the embedded drawing.
-	 * @return a {@link java.lang.String} object
+	 * @return a {@link String} object
 	 */
 	public String getRunDrawingFilename(R run) {
 		return getPic(run).getNvPicPr().getCNvPr().getName();
@@ -143,7 +143,7 @@ public class DocxImageExtractor {
 	 * Extract the content type of the image from an embedded image run.
 	 *
 	 * @param run run containing the embedded drawing.
-	 * @return a {@link java.lang.String} object
+	 * @return a {@link String} object
 	 */
 	public String getRunDrawingAltText(R run) {
 		return getPic(run).getNvPicPr().getCNvPr().getDescr();
@@ -153,7 +153,7 @@ public class DocxImageExtractor {
 	 * Extract the width of the image from an embedded image run.
 	 *
 	 * @param run run containing the embedded drawing.
-	 * @return a {@link java.lang.Integer} object
+	 * @return a {@link Integer} object
 	 */
 	public Integer getRunDrawingMaxWidth(R run) {
 		return (int) getPic(run).getSpPr().getXfrm().getExt().getCx();

--- a/src/main/java/org/wickedsource/docxstamper/util/IndexedRun.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/IndexedRun.java
@@ -3,7 +3,7 @@ package org.wickedsource.docxstamper.util;
 import org.docx4j.wml.R;
 
 /**
- * Represents a run (i.e. a text fragment) in a paragraph. The run is indexed relative to the containing paragraph
+ * Represents a run (i.e., a text fragment) in a paragraph. The run is indexed relative to the containing paragraph
  * and also relative to the containing document.
  * @param startIndex    the start index of the run relative to the containing paragraph.
  * @param endIndex       the end index of the run relative to the containing paragraph.

--- a/src/main/java/org/wickedsource/docxstamper/util/ObjectDeleter.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/ObjectDeleter.java
@@ -9,7 +9,7 @@ import org.wickedsource.docxstamper.api.DocxStamperException;
 import java.util.Iterator;
 
 /**
- * Utility class for deleting objects from a {@link org.docx4j.wml.Document}.
+ * Utility class for deleting objects from a {@link Document}.
  *
  * @author Joseph Verron
  * @version ${version}

--- a/src/main/java/org/wickedsource/docxstamper/util/ParagraphUtil.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/ParagraphUtil.java
@@ -23,7 +23,9 @@ public class ParagraphUtil {
 	/**
 	 * Creates a new paragraph.
 	 *
-	 * @param texts the text of this paragraph. If more than one text is specified each text will be placed within its own Run.
+	 * @param texts the text of this paragraph.
+	 *             If more than one text is specified,
+	 *             each text will be placed within its own Run.
 	 * @return a new paragraph containing the given text.
 	 */
 	public static P create(String... texts) {

--- a/src/main/java/org/wickedsource/docxstamper/util/ParagraphWrapper.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/ParagraphWrapper.java
@@ -14,8 +14,9 @@ import static java.util.stream.Collectors.joining;
  * relatively free in splitting a paragraph of text into multiple runs, so there is no strict rule to say over how many
  * runs a word or a string of words is spread.</p>
  * <p>This class aggregates multiple runs so they can be treated as a single text, no matter how many runs the text spans.
- * Call addRun() to add all runs that should be aggregated. Then, call methods to modify the aggregated text. Finally,
- * call getText() or getRuns() to get the modified text or the list of modified runs.</p>
+ * Call {@link #addRun(R, int)} to add all runs that should be aggregated. Then, call
+ * methods to modify the aggregated text. Finally, call {@link #getText()} or
+ * {@link #getRuns()} to get the modified text or  the list of modified runs.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -159,7 +160,7 @@ public class ParagraphWrapper {
 
 	/**
 	 * Returns the list of runs that are aggregated. Depending on what modifications were done to the aggregated text
-	 * this list may not return the same runs that were initially added to the aggregator.
+	 * this list may not return the same runs initially added to the aggregator.
 	 *
 	 * @return the list of aggregated runs.
 	 */
@@ -176,7 +177,7 @@ public class ParagraphWrapper {
 	/**
 	 * <p>Getter for the field <code>paragraph</code>.</p>
 	 *
-	 * @return a {@link org.docx4j.wml.P} object
+	 * @return a {@link P} object
 	 */
 	public P getParagraph() {
 		return paragraph;

--- a/src/main/java/org/wickedsource/docxstamper/util/RunUtil.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/RunUtil.java
@@ -27,7 +27,7 @@ public class RunUtil {
 	 * Returns the text string of a run.
 	 *
 	 * @param run the run whose text to get.
-	 * @return String representation of the run.
+	 * @return {@link String} representation of the run.
 	 */
 	public static String getText(R run) {
 		StringBuilder result = new StringBuilder();

--- a/src/main/java/org/wickedsource/docxstamper/util/SectionUtil.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/SectionUtil.java
@@ -29,8 +29,8 @@ public class SectionUtil {
 	/**
 	 * Creates a new section break object.
 	 *
-	 * @param firstObject a {@link java.lang.Object} object
-	 * @param parent      a {@link org.docx4j.wml.ContentAccessor} object
+	 * @param firstObject a {@link Object} object
+	 * @param parent      a {@link ContentAccessor} object
 	 * @return a new section break object.
 	 */
 	public static SectPr getPreviousSectionBreakIfPresent(Object firstObject, ContentAccessor parent) {
@@ -56,7 +56,7 @@ public class SectionUtil {
 	 * Creates a new section break object.
 	 *
 	 * @return a new section break object.
-	 * @param p a {@link org.docx4j.wml.P} object
+	 * @param p a {@link P} object
 	 */
 	public static SectPr getParagraphSectionBreak(P p) {
 		return p.getPPr() != null && p.getPPr().getSectPr() != null
@@ -68,7 +68,7 @@ public class SectionUtil {
 	 * Creates a new section break object.
 	 *
 	 * @return a new section break object.
-	 * @param objects a {@link java.util.List} object
+	 * @param objects a {@link List} object
 	 */
 	public static boolean isOddNumberOfSectionBreaks(List<Object> objects) {
 		long count = objects.stream()
@@ -82,8 +82,8 @@ public class SectionUtil {
 	/**
 	 * Creates a new section break object.
 	 *
-	 * @param sectPr a {@link org.docx4j.wml.SectPr} object
-	 * @param paragraph a {@link org.docx4j.wml.P} object
+	 * @param sectPr a {@link SectPr} object
+	 * @param paragraph a {@link P} object
 	 */
 	public static void applySectionBreakToParagraph(SectPr sectPr, P paragraph) {
 		PPr nextPPr = ofNullable(paragraph.getPPr())

--- a/src/main/java/org/wickedsource/docxstamper/util/walk/BaseCoordinatesWalker.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/walk/BaseCoordinatesWalker.java
@@ -4,7 +4,7 @@ import org.docx4j.wml.P;
 import org.docx4j.wml.R;
 
 /**
- * A {@link org.wickedsource.docxstamper.util.walk.CoordinatesWalker} that does nothing in the {@link #onRun(R, P)} and {@link #onParagraph(P)} methods.
+ * A {@link CoordinatesWalker} that does nothing in the {@link #onRun(R, P)} and {@link #onParagraph(P)} methods.
  *
  * @author Joseph Verron
  * @version ${version}

--- a/src/main/java/org/wickedsource/docxstamper/util/walk/BaseDocumentWalker.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/walk/BaseDocumentWalker.java
@@ -3,9 +3,9 @@ package org.wickedsource.docxstamper.util.walk;
 import org.docx4j.wml.*;
 
 /**
- * This class is an abstract implementation of the {@link org.wickedsource.docxstamper.util.walk.DocumentWalker} interface.
+ * This class is an abstract implementation of the {@link DocumentWalker} interface.
  * It implements all methods of the interface and does nothing in the individual methods.
- * This makes it easier to implement a custom {@link org.wickedsource.docxstamper.util.walk.DocumentWalker} because the implementor
+ * This makes it easier to implement a custom {@link DocumentWalker} because the implementor
  * only has to implement the methods that are of interest.
  *
  * @author Joseph Verron

--- a/src/main/java/org/wickedsource/docxstamper/util/walk/DocumentWalker.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/walk/DocumentWalker.java
@@ -2,28 +2,29 @@ package org.wickedsource.docxstamper.util.walk;
 
 import org.docx4j.XmlUtils;
 import org.docx4j.wml.*;
+import org.docx4j.wml.R.CommentReference;
 
 /**
  * This class walks the document and calls abstract methods for each element it encounters.
  * The following elements are supported:
  * <ul>
- * <li>{@link org.docx4j.wml.P}</li>
- * <li>{@link org.docx4j.wml.R}</li>
- * <li>{@link org.docx4j.wml.Tbl}</li>
- * <li>{@link org.docx4j.wml.Tr}</li>
- * <li>{@link org.docx4j.wml.Tc}</li>
- * <li>{@link org.docx4j.wml.CommentRangeStart}</li>
- * <li>{@link org.docx4j.wml.CommentRangeEnd}</li>
- * <li>{@link org.docx4j.wml.R.CommentReference}</li>
+ * <li>{@link P}</li>
+ * <li>{@link R}</li>
+ * <li>{@link Tbl}</li>
+ * <li>{@link Tr}</li>
+ * <li>{@link Tc}</li>
+ * <li>{@link CommentRangeStart}</li>
+ * <li>{@link CommentRangeEnd}</li>
+ * <li>{@link CommentReference}</li>
  * </ul>
  * The following elements are not supported:
  * <ul>
- * <li>{@link org.docx4j.wml.SdtBlock}</li>
- * <li>{@link org.docx4j.wml.SdtRun}</li>
- * <li>{@link org.docx4j.wml.SdtElement}</li>
- * <li>{@link org.docx4j.wml.CTSimpleField}</li>
- * <li>{@link org.docx4j.wml.CTSdtCell}</li>
- * <li>{@link org.docx4j.wml.CTSdtContentCell}</li>
+ * <li>{@link SdtBlock}</li>
+ * <li>{@link SdtRun}</li>
+ * <li>{@link SdtElement}</li>
+ * <li>{@link CTSimpleField}</li>
+ * <li>{@link CTSdtCell}</li>
+ * <li>{@link CTSdtContentCell}</li>
  * </ul>
  *
  * @author Joseph Verron
@@ -62,7 +63,7 @@ public abstract class DocumentWalker {
 				onCommentRangeStart(commentRangeStart);
 			} else if (unwrappedObject instanceof CommentRangeEnd commentRangeEnd) {
 				onCommentRangeEnd(commentRangeEnd);
-			} else if (unwrappedObject instanceof R.CommentReference commentReference) {
+			} else if (unwrappedObject instanceof CommentReference commentReference) {
 				onCommentReference(commentReference);
 			}
 		}
@@ -126,65 +127,65 @@ public abstract class DocumentWalker {
 		onRun(r);
 		for (Object element : r.getContent()) {
 			Object unwrappedObject = XmlUtils.unwrap(element);
-			if (unwrappedObject instanceof R.CommentReference commentReference) {
+			if (unwrappedObject instanceof CommentReference commentReference) {
 				onCommentReference(commentReference);
             }
         }
 	}
 
 	/**
-	 * This method is called for every {@link org.docx4j.wml.R} element in the document.
+	 * This method is called for every {@link R} element in the document.
 	 *
-	 * @param run the {@link org.docx4j.wml.R} element to process.
+	 * @param run the {@link R} element to process.
 	 */
 	protected abstract void onRun(R run);
 
 	/**
-	 * This method is called for every {@link org.docx4j.wml.P} element in the document.
+	 * This method is called for every {@link P} element in the document.
 	 *
-	 * @param paragraph the {@link org.docx4j.wml.P} element to process.
+	 * @param paragraph the {@link P} element to process.
 	 */
 	protected abstract void onParagraph(P paragraph);
 
 	/**
-	 * This method is called for every {@link org.docx4j.wml.Tbl} element in the document.
+	 * This method is called for every {@link Tbl} element in the document.
 	 *
-	 * @param table the {@link org.docx4j.wml.Tbl} element to process.
+	 * @param table the {@link Tbl} element to process.
 	 */
 	protected abstract void onTable(Tbl table);
 
 	/**
-	 * This method is called for every {@link org.docx4j.wml.Tc} element in the document.
+	 * This method is called for every {@link Tc} element in the document.
 	 *
-	 * @param tableCell the {@link org.docx4j.wml.Tc} element to process.
+	 * @param tableCell the {@link Tc} element to process.
 	 */
 	protected abstract void onTableCell(Tc tableCell);
 
 	/**
-	 * This method is called for every {@link org.docx4j.wml.Tr} element in the document.
+	 * This method is called for every {@link Tr} element in the document.
 	 *
-	 * @param tableRow the {@link org.docx4j.wml.Tr} element to process.
+	 * @param tableRow the {@link Tr} element to process.
 	 */
 	protected abstract void onTableRow(Tr tableRow);
 
 	/**
-	 * This method is called for every {@link org.docx4j.wml.CommentRangeStart} element in the document.
+	 * This method is called for every {@link CommentRangeStart} element in the document.
 	 *
-	 * @param commentRangeStart the {@link org.docx4j.wml.CommentRangeStart} element to process.
+	 * @param commentRangeStart the {@link CommentRangeStart} element to process.
 	 */
 	protected abstract void onCommentRangeStart(CommentRangeStart commentRangeStart);
 
 	/**
-	 * This method is called for every {@link org.docx4j.wml.CommentRangeEnd} element in the document.
+	 * This method is called for every {@link CommentRangeEnd} element in the document.
 	 *
-	 * @param commentRangeEnd the {@link org.docx4j.wml.CommentRangeEnd} element to process.
+	 * @param commentRangeEnd the {@link CommentRangeEnd} element to process.
 	 */
 	protected abstract void onCommentRangeEnd(CommentRangeEnd commentRangeEnd);
 
 	/**
-	 * This method is called for every {@link org.docx4j.wml.R.CommentReference} element in the document.
+	 * This method is called for every {@link CommentReference} element in the document.
 	 *
-	 * @param commentReference the {@link org.docx4j.wml.R.CommentReference} element to process.
+	 * @param commentReference the {@link CommentReference} element to process.
 	 */
-	protected abstract void onCommentReference(R.CommentReference commentReference);
+	protected abstract void onCommentReference(CommentReference commentReference);
 }

--- a/src/main/java/pro/verron/docxstamper/OpcStamper.java
+++ b/src/main/java/pro/verron/docxstamper/OpcStamper.java
@@ -6,7 +6,8 @@ import org.wickedsource.docxstamper.api.DocxStamperException;
 import java.io.OutputStream;
 
 /**
- * OpcStamper is an interface that defines the contract for stamping templates with context and writing the result to an OutputStream.
+ * OpcStamper is an interface that defines the contract for stamping
+ * templates with context and writing the result to an {@link OutputStream}.
  *
  * @param <T> The type of the template that can be stamped.
  * @author Joseph Verron
@@ -19,7 +20,7 @@ public interface OpcStamper<T extends OpcPackage> {
 	 * @param template     template to stamp
 	 * @param context      context to use for stamping
 	 * @param outputStream output stream to write the result to
-	 * @throws org.wickedsource.docxstamper.api.DocxStamperException if the stamping fails
+	 * @throws DocxStamperException if the stamping fails
 	 */
 	void stamp(T template, Object context, OutputStream outputStream) throws DocxStamperException;
 }

--- a/src/main/java/pro/verron/docxstamper/StamperFactory.java
+++ b/src/main/java/pro/verron/docxstamper/StamperFactory.java
@@ -19,7 +19,7 @@ public class StamperFactory {
 
 	/**
 	 * Creates a new DocxStamper with the default configuration.
-	 * Also adds the {@link org.wickedsource.docxstamper.preprocessor.RemoveProofErrors} and {@link org.wickedsource.docxstamper.preprocessor.MergeSameStyleRuns} preprocessors.
+	 * Also adds the {@link RemoveProofErrors} and {@link MergeSameStyleRuns} preprocessors.
 	 *
 	 * @return a new DocxStamper
 	 */

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/DateResolver.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/DateResolver.java
@@ -1,11 +1,15 @@
 package pro.verron.docxstamper.preset.resolver;
 
+import pro.verron.docxstamper.api.ObjectResolver;
+
+import java.text.SimpleDateFormat;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 /**
- * This ITypeResolver creates a formatted date String for expressions that return a Date object.
+ * This {@link ObjectResolver} creates a formatted date {@link String} for
+ * expressions that return a {@link Date} object.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -25,7 +29,8 @@ public final class DateResolver
     /**
      * Creates a new DateResolver.
      *
-     * @param formatter the format to use for date formatting. See java.text.SimpleDateFormat.
+     * @param formatter the format to use for date formatting. See
+     * {@link SimpleDateFormat}.
      */
     public DateResolver(DateTimeFormatter formatter) {
         super(Date.class);
@@ -33,9 +38,9 @@ public final class DateResolver
     }
 
     /**
-     * Resolves a formatted date string for the given Date object.
+     * Resolves a formatted date string for the given {@link Date} object.
      *
-     * @param date the Date object to be resolved.
+     * @param date the {@link Date} object to be resolved.
      * @return the formatted date string.
      */
     @Override

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/ImageResolver.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/ImageResolver.java
@@ -15,9 +15,10 @@ import java.util.Random;
 import static org.docx4j.openpackaging.parts.WordprocessingML.BinaryPartAbstractImage.createImagePart;
 
 /**
- * This ITypeResolver allows context objects to return objects of type Image. An expression that resolves to an Image
- * object will be replaced by an actual image in the resulting .docx document. The image will be put as an inline into
- * the surrounding paragraph of text.
+ * This {@link ObjectResolver} allows context objects to return objects of
+ * type {@link Image}. An expression that resolves to an {@link Image}
+ * object will be replaced by an actual image in the resulting .docx document.
+ * The image will be put as an inline into the surrounding paragraph of text.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -92,7 +93,8 @@ public class ImageResolver
     }
 
     /**
-     * Resolves an image and adds it to a WordprocessingMLPackage document.
+     * Resolves an image and adds it to a {@link WordprocessingMLPackage}
+     * document.
      *
      * @param document The WordprocessingMLPackage document
      * @param image    The image to be resolved and added

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/LocalDateResolver.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/LocalDateResolver.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 /**
- * Resolves {@link java.time.LocalDate} objects by formatting them with a {@link java.time.format.DateTimeFormatter}.
+ * Resolves {@link LocalDate} objects by formatting them with a {@link DateTimeFormatter}.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -14,7 +14,7 @@ public final class LocalDateResolver
 	private final DateTimeFormatter formatter;
 
 	/**
-	 * Uses {@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE} for formatting.
+	 * Uses {@link DateTimeFormatter#ISO_LOCAL_DATE} for formatting.
 	 */
 	public LocalDateResolver() {
 		this(DateTimeFormatter.ISO_LOCAL_DATE);

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/LocalDateTimeResolver.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/LocalDateTimeResolver.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 /**
- * Resolves {@link java.time.LocalDateTime} values to a formatted string.
+ * Resolves {@link LocalDateTime} values to a formatted string.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -14,7 +14,7 @@ public final class LocalDateTimeResolver
 	private final DateTimeFormatter formatter;
 
 	/**
-	 * Creates a new resolver that uses {@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME} to format {@link java.time.LocalDateTime}
+	 * Creates a new resolver that uses {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME} to format {@link LocalDateTime}
 	 * values.
 	 */
 	public LocalDateTimeResolver() {
@@ -22,7 +22,7 @@ public final class LocalDateTimeResolver
 	}
 
 	/**
-	 * Creates a new resolver that uses the given formatter to format {@link java.time.LocalDateTime} values.
+	 * Creates a new resolver that uses the given formatter to format {@link LocalDateTime} values.
 	 *
 	 * @param formatter the formatter to use.
 	 */

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/LocalTimeResolver.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/LocalTimeResolver.java
@@ -4,7 +4,7 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 /**
- * Resolves {@link java.time.LocalTime} values to the format specified by the {@link java.time.format.DateTimeFormatter} passed to the constructor.
+ * Resolves {@link LocalTime} values to the format specified by the {@link DateTimeFormatter} passed to the constructor.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -14,7 +14,7 @@ public final class LocalTimeResolver
 	private final DateTimeFormatter formatter;
 
 	/**
-	 * Uses {@link java.time.format.DateTimeFormatter#ISO_LOCAL_TIME} for formatting.
+	 * Uses {@link DateTimeFormatter#ISO_LOCAL_TIME} for formatting.
 	 */
 	public LocalTimeResolver() {
 		this(DateTimeFormatter.ISO_LOCAL_TIME);
@@ -23,7 +23,7 @@ public final class LocalTimeResolver
 	/**
 	 * <p>Constructor for LocalTimeResolver.</p>
 	 *
-	 * @param formatter a date time pattern as specified by {@link java.time.format.DateTimeFormatter#ofPattern(String)}
+	 * @param formatter a date time pattern as specified by {@link DateTimeFormatter#ofPattern(String)}
 	 */
 	public LocalTimeResolver(DateTimeFormatter formatter) {
 		super(LocalTime.class);

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/Null2DefaultResolver.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/Null2DefaultResolver.java
@@ -6,7 +6,8 @@ import org.wickedsource.docxstamper.util.RunUtil;
 import pro.verron.docxstamper.api.ObjectResolver;
 
 /**
- * The Null2DefaultResolver class is an implementation of the ObjectResolver interface
+ * The Null2DefaultResolver class is an implementation of the
+ * {@link ObjectResolver} interface
  * that resolves null objects by creating a run with a default text value.
  *
  * @version ${version}
@@ -36,9 +37,9 @@ public class Null2DefaultResolver
     }
 
     /**
-     * Retrieves the default value of the Null2DefaultResolver object.
+     * Retrieves the default value of the {@link Null2DefaultResolver} object.
      *
-     * @return the default value of the Null2DefaultResolver object as a String
+     * @return the default value of the {@link Null2DefaultResolver} object as a String
      */
     public String defaultValue() {
         return text;

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/Null2PlaceholderResolver.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/Null2PlaceholderResolver.java
@@ -6,7 +6,7 @@ import org.wickedsource.docxstamper.util.RunUtil;
 import pro.verron.docxstamper.api.ObjectResolver;
 
 /**
- * The Null2PlaceholderResolver class is an implementation of the ObjectResolver interface.
+ * The {@link Null2PlaceholderResolver} class is an implementation of the ObjectResolver interface.
  * It provides a way to resolve null objects by not replacing their placeholder string.
  *
  * @author Joseph Verron

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/Resolvers.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/Resolvers.java
@@ -1,11 +1,17 @@
 package pro.verron.docxstamper.preset.resolver;
 
+import org.wickedsource.docxstamper.replace.typeresolver.image.Image;
 import pro.verron.docxstamper.api.ObjectResolver;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
 
 /**
- * The Resolvers class provides static methods to create different types of ObjectResolvers.
+ * This class provides static methods to create different types of
+ * {@link ObjectResolver}.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -14,126 +20,144 @@ import java.time.format.DateTimeFormatter;
 public class Resolvers {
 
     /**
-     * Returns an instance of ObjectResolver that acts as a fallback resolver.
-     * It uses the ToStringResolver implementation of ObjectResolver.
+     * Returns an instance of {@link ObjectResolver} that can act as a fallback
+     * resolver. Will call the {@link Object#toString()} method on every type
+     * of objects.
      *
-     * @return An instance of ObjectResolver
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver fallback() {
         return new ToStringResolver();
     }
 
     /**
-     * Returns an instance of ObjectResolver that replaces null values with an empty string.
+     * Returns an instance of {@link ObjectResolver} that replaces null values with an empty string.
      *
-     * @return An instance of ObjectResolver
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver nullToEmpty() {
         return nullToDefault("");
     }
 
     /**
-     * Returns an instance of ObjectResolver that resolves null objects
+     * Returns an instance of {@link ObjectResolver} that resolves null objects
      * by creating a run with a default text value.
      *
      * @param value The default value for null objects.
-     * @return An instance of ObjectResolver
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver nullToDefault(String value) {
         return new Null2DefaultResolver(value);
     }
 
     /**
-     * Returns an instance of ObjectResolver that resolves null objects
+     * Returns an instance of {@link ObjectResolver} that resolves null objects
      * by not replacing their placeholder string.
      *
-     * @return An instance of ObjectResolver
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver nullToPlaceholder() {
         return new Null2PlaceholderResolver();
     }
 
     /**
-     * Returns an instance of LocalTimeResolver.
-     * The LocalTimeResolver class is an implementation of the StringResolver interface
-     * that resolves LocalTime values to a formatted string using the ISO_LOCAL_TIME pattern.
+     * Returns an instance of {@link ObjectResolver} that resolves
+     * {@link LocalDateTime} values to a formatted string using the
+     * {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME} pattern.
      *
-     * @return An instance of LocalTimeResolver
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver isoDateTime() {
-        return new LocalTimeResolver();
-    }
-
-    /**
-     * Returns an instance of {@link LocalDateTimeResolver}.
-     * The LocalDateTimeResolver class is an implementation of the {@link ObjectResolver} interface
-     * that resolves {@link java.time.LocalDateTime} values to a formatted string.
-     *
-     * @return An instance of LocalDateTimeResolver
-     */
-    public static ObjectResolver isoTime() {
         return new LocalDateTimeResolver();
     }
 
     /**
-     * Creates a new instance of LocalDateTimeResolver using the given formatter.
+     * Returns an instance of {@link ObjectResolver} that resolves
+     * {@link LocalTime} values to a formatted string using the
+     * {@link DateTimeFormatter#ISO_LOCAL_TIME} pattern.
      *
-     * @param formatter the DateTimeFormatter to use for formatting LocalDateTime values
-     * @return a new instance of LocalDateTimeResolver
+     * @return An instance of {@link ObjectResolver}
      */
-    public static ObjectResolver isoTime(DateTimeFormatter formatter) {
-        return new LocalDateTimeResolver(formatter);
+    public static ObjectResolver isoTime() {
+        return new LocalTimeResolver();
     }
 
     /**
-     * Returns an instance of {@link LocalDateResolver}.
-     * The LocalDateResolver class is an implementation of the {@link StringResolver} interface
-     * that resolves {@link java.time.LocalDate} objects by formatting them with a {@link DateTimeFormatter}.
+     * Returns an instance of {@link ObjectResolver} that resolves
+     * {@link LocalDate} values to a formatted string using the
+     * {@link DateTimeFormatter#ISO_LOCAL_DATE} pattern.
      *
-     * @return An instance of LocalDateResolver
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver isoDate() {
         return new LocalDateResolver();
     }
 
     /**
-     * Returns an instance of LocalDateResolver that resolves {@link java.time.LocalDate} objects
-     * by formatting them with the given {@link DateTimeFormatter}.
+     * Returns an instance of {@link ObjectResolver} that resolves
+     * {@link LocalTime} values to a formatted string using the given
+     * {@link DateTimeFormatter} pattern.
      *
-     * @param formatter the DateTimeFormatter to use for formatting LocalDate values
-     * @return an instance of LocalDateResolver
+     * @param formatter the {@link DateTimeFormatter} pattern to use
+     * @return An instance of {@link ObjectResolver}
+     */
+    public static ObjectResolver isoTime(DateTimeFormatter formatter) {
+        return new LocalTimeResolver(formatter);
+    }
+
+    /**
+     * Returns an instance of {@link ObjectResolver} that resolves
+     * {@link LocalDate} values to a formatted string using the given
+     * {@link DateTimeFormatter} pattern.
+     *
+     * @param formatter the {@link DateTimeFormatter} pattern to use
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver isoDate(DateTimeFormatter formatter) {
         return new LocalDateResolver(formatter);
     }
 
     /**
-     * Returns an instance of DateResolver.
-     * The DateResolver class is an implementation of the StringResolver interface
-     * that creates a formatted date string for expressions that return a Date object.
+     * Returns an instance of {@link ObjectResolver} that resolves
+     * {@link LocalDateTime} values to a formatted string using the given
+     * {@link DateTimeFormatter} pattern.
      *
-     * @return An instance of DateResolver
+     * @param formatter the {@link DateTimeFormatter} pattern to use
+     * @return An instance of {@link ObjectResolver}
+     */
+    public static ObjectResolver isoDateTime(DateTimeFormatter formatter) {
+        return new LocalDateTimeResolver(formatter);
+    }
+
+    /**
+     * Returns an instance of {@link ObjectResolver} that resolves
+     * {@link Date} values to a formatted string using the
+     * "dd.MM.yyyy" pattern.
+     *
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver legacyDate() {
         return new DateResolver();
     }
 
     /**
-     * This method returns an instance of DateResolver that creates a formatted date string for expressions that return a Date object.
+     * Returns an instance of {@link ObjectResolver} that resolves
+     * {@link Date} values to a formatted string using the given
+     * {@link DateTimeFormatter} pattern.
      *
-     * @param formatter the format to use for date formatting. See java.time.format.DateTimeFormatter.
-     * @return an instance of DateResolver
+     * @param formatter the {@link DateTimeFormatter} pattern to use
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver legacyDate(DateTimeFormatter formatter) {
         return new DateResolver(formatter);
     }
 
     /**
-     * Returns an instance of ImageResolver that allows context objects to return objects of type Image.
-     * An expression that resolves to an Image object will be replaced by an actual image in the resulting .docx document.
+     * Returns an instance of {@link ObjectResolver} that resolves
+     * {@link Image} to an actual image in the resulting .docx document.
      * The image will be put as an inline into the surrounding paragraph of text.
      *
-     * @return An instance of ImageResolver
+     * @return An instance of {@link ObjectResolver}
      */
     public static ObjectResolver image() {
         return new ImageResolver();

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/StringResolver.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/StringResolver.java
@@ -6,8 +6,9 @@ import org.wickedsource.docxstamper.util.RunUtil;
 import pro.verron.docxstamper.api.ObjectResolver;
 
 /**
- * A StringResolver is an abstract class that provides a generic implementation for resolving objects
- * to strings. It is used in conjunction with ObjectResolver interface to provide a flexible way to
+ * This is an abstract class that provides a generic implementation for
+ * resolving objects to strings. It is used in conjunction with
+ * {@link ObjectResolver} interface to provide a flexible way to
  * resolve different types of objects to strings.
  *
  * @param <T> the type of the object to resolve

--- a/src/main/java/pro/verron/docxstamper/preset/resolver/ToStringResolver.java
+++ b/src/main/java/pro/verron/docxstamper/preset/resolver/ToStringResolver.java
@@ -6,9 +6,9 @@ import org.wickedsource.docxstamper.util.RunUtil;
 import pro.verron.docxstamper.api.ObjectResolver;
 
 /**
- * The ToStringResolver class is an implementation of the ObjectResolver interface
+ * This class is an implementation of the {@link ObjectResolver} interface
  * that resolves objects by converting them to a string representation using the
- * `toString()` method and creating a new run with the resolved content.
+ * {@link Object#toString()} method and creating a new run with the resolved content.
  */
 public class ToStringResolver
         implements ObjectResolver {

--- a/src/main/java/pro/verron/docxstamper/utils/ProcessorExceptionHandler.java
+++ b/src/main/java/pro/verron/docxstamper/utils/ProcessorExceptionHandler.java
@@ -6,16 +6,24 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * The ProcessorExceptionHandler class is responsible for capturing and handling uncaught exceptions that occur in a thread.
- * It implements the Thread.UncaughtExceptionHandler interface and can be assigned to a thread using the setUncaughtExceptionHandler() method.
- * When an exception occurs in the thread, the uncaughtException() method of ProcessorExceptionHandler will be called.
+ * This class is responsible for capturing and handling uncaught exceptions
+ * that occur in a thread.
+ * It implements the {@link Thread.UncaughtExceptionHandler} interface and can
+ * be assigned to a thread using the
+ * {@link Thread#setUncaughtExceptionHandler(Thread.UncaughtExceptionHandler)} method.
+ * When an exception occurs in the thread,
+ * the {@link ProcessorExceptionHandler#uncaughtException(Thread, Throwable)}
+ * method will be called.
  * This class provides the following features:
  * 1. Capturing and storing the uncaught exception.
  * 2. Executing a list of routines when an exception occurs.
  * 3. Providing access to the captured exception, if any.
  * Example usage:
- * ProcessorExceptionHandler exceptionHandler = new ProcessorExceptionHandler();
+ * <code>
+ * ProcessorExceptionHandler exceptionHandler = new
+ * ProcessorExceptionHandler(){};
  * thread.setUncaughtExceptionHandler(exceptionHandler);
+ * </code>
  *
  * @see Thread.UncaughtExceptionHandler
  * @author Joseph Verron
@@ -27,7 +35,7 @@ public class ProcessorExceptionHandler
     private final List<Runnable> onException;
 
     /**
-     * Constructs a new ProcessorExceptionHandler for managing thread's uncaught exceptions.
+     * Constructs a new instance for managing thread's uncaught exceptions.
      * Once set to a thread, it retains the exception information and performs specified routines.
      */
     public ProcessorExceptionHandler() {
@@ -60,8 +68,8 @@ public class ProcessorExceptionHandler
     /**
      * Returns the captured exception if present.
      *
-     * @return an Optional containing the captured exception,
-     * or an empty Optional if no exception was captured
+     * @return an {@link Optional} containing the captured exception,
+     * or an {@link Optional#empty()} if no exception was captured
      */
     public Optional<Throwable> exception() {
         return Optional.ofNullable(exception.get());

--- a/src/main/java/pro/verron/docxstamper/utils/ThrowingRunnable.java
+++ b/src/main/java/pro/verron/docxstamper/utils/ThrowingRunnable.java
@@ -5,9 +5,9 @@ import org.wickedsource.docxstamper.api.DocxStamperException;
 
 /**
  * A functional interface representing runnable task able to throw an exception.
- * It extends the {@link java.lang.Runnable} interface and provides default implementation
- * of the {@link java.lang.Runnable#run()} method handling the exception by rethrowing it
- * wrapped inside a {@link org.wickedsource.docxstamper.api.DocxStamperException}.
+ * It extends the {@link Runnable} interface and provides default implementation
+ * of the {@link Runnable#run()} method handling the exception by rethrowing it
+ * wrapped inside a {@link DocxStamperException}.
  *
  * @author Joseph Verron
  * @version ${version}
@@ -17,7 +17,7 @@ public interface ThrowingRunnable
 
     /**
      * Executes the runnable task, handling any exception by throwing it wrapped
-     * inside a {@link org.wickedsource.docxstamper.api.DocxStamperException}.
+     * inside a {@link DocxStamperException}.
      */
     default void run() {
         try {
@@ -30,7 +30,7 @@ public interface ThrowingRunnable
     /**
      * Executes the runnable task
      *
-     * @throws java.lang.Exception if an exception occurs executing the task
+     * @throws Exception if an exception occurs executing the task
      */
     void throwingRun() throws Exception;
 }


### PR DESCRIPTION
Improved the clarity and consistency of javadocs across the codebase. This includes better use of the javadoc link feature and updating phrasing and grammar for more precise descriptions.