### PR TITLE
Update docx4j dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </description>
     <url>https://github.com/verronpro/docx-stamper</url>
     <properties>
-        <docx4j.version>11.4.9</docx4j.version>
+        <docx4j.version>11.4.11</docx4j.version>
     </properties>
     <scm>
         <url>https://github.com/verronpro/docx-stamper</url>
@@ -295,7 +295,7 @@
         <dependency>
             <groupId>org.docx4j</groupId>
             <artifactId>docx4j-core</artifactId>
-            <version>11.4.9</version>
+            <version>${docx4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>


### PR DESCRIPTION
This commit updates the docx4j dependency version in pom.xml from 11.4.9 to 11.4.11. The change helps to incorporate improvements and fixes from the latest versions, ensuring that our project stays current and stable.