### PR TITLE
Update dependency in pom.xml

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,9 +16,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>pro.verron</groupId>
-            <artifactId>docx-stamper</artifactId>
-            <version>1.6.8</version>
+            <groupId>pro.verron.office-stamper</groupId>
+            <artifactId>engine</artifactId>
+            <version>2.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The commit changes the dependency in the pom.xml file. It has replaced 'pro.verron:docx-stamper:1.6.8' with 'pro.verron.office-stamper:engine:2.0-SNAPSHOT'. This ensures the use of updated and relevant applications in the software system.