### PR TITLE
[test] Refactor TestUtils for resource retrieval

### DIFF
--- a/engine/src/test/java/pro/verron/officestamper/test/BasicExcelTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/BasicExcelTest.java
@@ -4,7 +4,6 @@ import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.docx4j.openpackaging.packages.SpreadsheetMLPackage.load;
@@ -20,8 +19,7 @@ public class BasicExcelTest {
             throws IOException, Docx4JException {
 
         var stamper = xlsxStamper();
-        var templatePath = Path.of("test", "sources", "excel-base.xlsx");
-        var templateStream = Files.newInputStream(templatePath);
+        var templateStream = TestUtils.getResource(Path.of("excel-base.xlsx"));
 
         var templatePackage = load(templateStream);
         var templateExpectedString = """

--- a/engine/src/test/java/pro/verron/officestamper/test/BasicPowerpointTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/BasicPowerpointTest.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
 
-import static java.nio.file.Files.newInputStream;
 import static pro.verron.officestamper.preset.ExperimentalStampers.pptxStamper;
 import static pro.verron.officestamper.test.IOStreams.getInputStream;
 import static pro.verron.officestamper.test.IOStreams.getOutputStream;
@@ -20,8 +19,8 @@ public class BasicPowerpointTest {
     public void testStamper()
             throws IOException, Docx4JException {
         var stamper = pptxStamper();
-        var templatePath = Path.of("test", "sources", "powerpoint-base.pptx");
-        var templateStream = newInputStream(templatePath);
+        var templateStream = TestUtils.getResource(Path.of("powerpoint-base.pptx"));
+
         record Person(String name) {}
         var context = new Person("Bart");
         PresentationMLPackage load = PresentationMLPackage.load(templateStream);

--- a/engine/src/test/java/pro/verron/officestamper/test/BasicWordTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/BasicWordTest.java
@@ -2,8 +2,6 @@ package pro.verron.officestamper.test;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,12 +9,11 @@ import static pro.verron.officestamper.preset.OfficeStamperConfigurations.standa
 
 public class BasicWordTest {
     @Test
-    public void testStamper()
-            throws IOException {
+    public void testStamper() {
         var stamperConfiguration = standardWithPreprocessing();
         var stamper = new TestDocxStamper<>(stamperConfiguration);
-        var templatePath = Path.of("test", "sources", "word-base.docx");
-        var templateStream = Files.newInputStream(templatePath);
+        var templateStream = TestUtils.getResource(Path.of("word-base.docx"));
+
         record Person(String name) {}
         var context = new Person("Bart");
         var actual = stamper.stampAndLoadAndExtract(templateStream

--- a/engine/src/test/java/pro/verron/officestamper/test/DefaultTests.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/DefaultTests.java
@@ -14,7 +14,6 @@ import pro.verron.officestamper.preset.Resolvers;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.List;
@@ -25,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.junit.jupiter.params.provider.Arguments.of;
 import static pro.verron.officestamper.test.Contexts.*;
+import static pro.verron.officestamper.test.TestUtils.getResource;
 
 /**
  * <p>DefaultTests class.</p>
@@ -1203,23 +1203,6 @@ public class DefaultTests {
                         Visited
                         This paragraph is untouched.
                         Visited""");
-    }
-
-    /**
-     * <p>getResource.</p>
-     *
-     * @param path a {@link java.nio.file.Path} object
-     *
-     * @return a {@link java.io.InputStream} object
-     */
-    public static InputStream getResource(Path path) {
-        try {
-            var testRoot = Path.of("test", "sources");
-            var resolve = testRoot.resolve(path);
-            return Files.newInputStream(resolve);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @MethodSource("tests")

--- a/engine/src/test/java/pro/verron/officestamper/test/FailOnUnresolvedPlaceholderTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/FailOnUnresolvedPlaceholderTest.java
@@ -2,7 +2,6 @@ package pro.verron.officestamper.test;
 
 import org.junit.jupiter.api.Test;
 import pro.verron.officestamper.api.OfficeStamperException;
-import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,7 +9,9 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static pro.verron.officestamper.test.DefaultTests.getResource;
+import static pro.verron.officestamper.preset.OfficeStamperConfigurations.standard;
+import static pro.verron.officestamper.test.TestUtils.getResource;
+
 
 /**
  * @author Joseph Verron
@@ -18,24 +19,27 @@ import static pro.verron.officestamper.test.DefaultTests.getResource;
  */
 class FailOnUnresolvedPlaceholderTest {
     @Test
-    void fails() throws IOException {
+    void fails()
+            throws IOException {
         var context = new Name("Homer");
-        try (var template = getResource(Path.of("FailOnUnresolvedExpressionTest" +
-                                                ".docx"))) {
-            var config = OfficeStamperConfigurations.standard()
+        try (var template = getResource("FailOnUnresolvedExpressionTest.docx")) {
+            var config = standard()
                     .setFailOnUnresolvedExpression(true);
             var stamper = new TestDocxStamper<>(config);
             assertThrows(OfficeStamperException.class,
-                         () -> stamper.stampAndLoad(template, context));
+                    () -> stamper.stampAndLoad(template, context));
         }
     }
 
     @Test
-    void doesNotFail() throws IOException {
+    void doesNotFail()
+            throws IOException {
         Name context = new Name("Homer");
-        try (InputStream template = getResource(Path.of(
-                "FailOnUnresolvedExpressionTest.docx"))) {
-            var config = OfficeStamperConfigurations.standard()
+        try (
+                InputStream template = getResource(Path.of(
+                        "FailOnUnresolvedExpressionTest.docx"))
+        ) {
+            var config = standard()
                     .setFailOnUnresolvedExpression(false);
             var stamper = new TestDocxStamper<>(config);
             assertDoesNotThrow(() -> stamper.stampAndLoad(template, context));

--- a/engine/src/test/java/pro/verron/officestamper/test/MultiSectionTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/MultiSectionTest.java
@@ -3,10 +3,8 @@ package pro.verron.officestamper.test;
 import org.junit.jupiter.api.Test;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 
-import java.nio.file.Path;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static pro.verron.officestamper.test.DefaultTests.getResource;
+import static pro.verron.officestamper.test.TestUtils.getResource;
 
 /**
  * @author Joseph Verron
@@ -16,18 +14,17 @@ class MultiSectionTest {
     @Test
     void expressionsInMultipleSections() {
         var context = new NamesContext("Homer", "Marge");
-        var template = getResource(Path.of("MultiSectionTest.docx"));
+        var template = getResource("MultiSectionTest.docx");
         var configuration = OfficeStamperConfigurations.standard();
         var stamper = new TestDocxStamper<NamesContext>(configuration);
         var actual = stamper.stampAndLoadAndExtract(template, context);
         String expected = """
                 Homer
-                        
+                                
                 ❬❘docGrid=xxx,eGHdrFtrReferences=xxx,pgMar=xxx,pgSz={h=16838,w=11906}❭
                 Marge""";
         assertEquals(expected, actual);
     }
-
 
     public record NamesContext(String firstName, String secondName) {
     }

--- a/engine/src/test/java/pro/verron/officestamper/test/MultiStampTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/MultiStampTest.java
@@ -3,11 +3,9 @@ package pro.verron.officestamper.test;
 import org.junit.jupiter.api.Test;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 
-import java.nio.file.Path;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static pro.verron.officestamper.test.Contexts.names;
-import static pro.verron.officestamper.test.DefaultTests.getResource;
+import static pro.verron.officestamper.test.TestUtils.getResource;
 
 /**
  * @author Joseph Verron
@@ -20,9 +18,8 @@ class MultiStampTest {
         var context = names("Homer","Marge","Bart","Lisa","Maggie");
         var stamper = new TestDocxStamper<>(config);
 
-        var templatePath = Path.of("MultiStampTest.docx");
-
-        var template1 = getResource(templatePath);
+        var filename = "MultiStampTest.docx";
+        var template1 = getResource(filename);
         var document1 = stamper.stampAndLoadAndExtract(template1, context);
         assertEquals("""
                              ❬Multi-Stamp-Test❘spacing={after=120,before=240}❭
@@ -34,7 +31,7 @@ class MultiStampTest {
                              ❬❘spacing={after=140,before=0}❭""",
                      document1);
 
-        var template2 = getResource(templatePath);
+        var template2 = getResource(filename);
         var document2 = stamper.stampAndLoadAndExtract(template2, context);
         assertEquals("""
                              ❬Multi-Stamp-Test❘spacing={after=120,before=240}❭

--- a/engine/src/test/java/pro/verron/officestamper/test/NullPointerResolutionTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/NullPointerResolutionTest.java
@@ -5,24 +5,22 @@ import pro.verron.officestamper.api.OfficeStamperException;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static pro.verron.officestamper.test.DefaultTests.getResource;
+import static pro.verron.officestamper.test.TestUtils.getResource;
 
 /**
  * @author Joseph Verron
  */
 class NullPointerResolutionTest {
     @Test
-    void nullPointerResolutionTest_testThrowingCase() throws IOException {
+    void nullPointerResolutionTest_testThrowingCase()
+            throws IOException {
         var subContext = new SubContext("Fullish2",
-                                        List.of("Fullish3", "Fullish4",
-                                                "Fullish5"));
+                List.of("Fullish3", "Fullish4", "Fullish5"));
         var context = new NullishContext("Fullish1", subContext, null, null);
-        try (var template =
-                     getResource(Path.of("NullPointerResolution.docx"))) {
+        try (var template = getResource("NullPointerResolution.docx")) {
             var configuration = OfficeStamperConfigurations.standard();
             var stamper = new TestDocxStamper<NullishContext>(configuration);
             assertThrows(

--- a/engine/src/test/java/pro/verron/officestamper/test/PlaceholderReplacementInHeaderAndFooterTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/PlaceholderReplacementInHeaderAndFooterTest.java
@@ -1,12 +1,11 @@
 package pro.verron.officestamper.test;
 
 import org.junit.jupiter.api.Test;
-import pro.verron.officestamper.preset.OfficeStamperConfigurations;
-
-import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static pro.verron.officestamper.test.DefaultTests.getResource;
+import static pro.verron.officestamper.preset.OfficeStamperConfigurations.standard;
+import static pro.verron.officestamper.test.TestUtils.getResource;
+
 
 /**
  * @author Joseph Verron
@@ -16,22 +15,21 @@ class PlaceholderReplacementInHeaderAndFooterTest {
     @Test
     void expressionReplacementInHeaderAndFooterTest() {
         var context = new Name("Homer Simpson");
-        var template = getResource(
-                Path.of("ExpressionReplacementInHeaderAndFooterTest.docx"));
-        var configuration = OfficeStamperConfigurations.standard()
+        var template = getResource("ExpressionReplacementInHeaderAndFooterTest.docx");
+        var configuration = standard()
                 .setFailOnUnresolvedExpression(false);
         var stamper = new TestDocxStamper<Name>(configuration);
         var actual = stamper.stampAndLoadAndExtract(template, context);
         assertEquals("""
-                             ❬❬This ❘lang=de-DE❭❬header ❘lang=de-DE❭❬paragraph is untouched.❘lang=de-DE❭❘lang=de-DE❭
-                             ❬❬In this paragraph, the variable ❘lang=de-DE❭❬name❘b=true,lang=de-DE❭ should be resolved to the value ❬Homer Simpson❘lang=de-DE❭.❘lang=de-DE❭
-                             ❬❬In this paragraph, the variable ❘lang=de-DE❭❬foo❘b=true,lang=de-DE❭❬ should not be resolved: ${foo}.❘lang=de-DE❭❘lang=de-DE,spacing={after=140,before=0}❭
-                             ❬Expression Replacement in header and footer❘spacing={after=120,before=240}❭
-                             ❬❘spacing={after=140,before=0}❭
-                             ❬❬This ❘lang=de-DE❭❬footer ❘lang=de-DE❭❬paragraph is untouched.❘lang=de-DE❭❘lang=de-DE❭
-                             ❬❬In this paragraph, the variable ❘lang=de-DE❭❬name❘b=true,lang=de-DE❭ should be resolved to the value ❬Homer Simpson❘lang=de-DE❭.❘lang=de-DE❭
-                             ❬❬In this paragraph, the variable ❘lang=de-DE❭❬foo❘b=true,lang=de-DE❭❬ should not be resolved: ${foo}.❘lang=de-DE❭❘lang=de-DE,spacing={after=140,before=0}❭""",
-                     actual);
+                        ❬❬This ❘lang=de-DE❭❬header ❘lang=de-DE❭❬paragraph is untouched.❘lang=de-DE❭❘lang=de-DE❭
+                        ❬❬In this paragraph, the variable ❘lang=de-DE❭❬name❘b=true,lang=de-DE❭ should be resolved to the value ❬Homer Simpson❘lang=de-DE❭.❘lang=de-DE❭
+                        ❬❬In this paragraph, the variable ❘lang=de-DE❭❬foo❘b=true,lang=de-DE❭❬ should not be resolved: ${foo}.❘lang=de-DE❭❘lang=de-DE,spacing={after=140,before=0}❭
+                        ❬Expression Replacement in header and footer❘spacing={after=120,before=240}❭
+                        ❬❘spacing={after=140,before=0}❭
+                        ❬❬This ❘lang=de-DE❭❬footer ❘lang=de-DE❭❬paragraph is untouched.❘lang=de-DE❭❘lang=de-DE❭
+                        ❬❬In this paragraph, the variable ❘lang=de-DE❭❬name❘b=true,lang=de-DE❭ should be resolved to the value ❬Homer Simpson❘lang=de-DE❭.❘lang=de-DE❭
+                        ❬❬In this paragraph, the variable ❘lang=de-DE❭❬foo❘b=true,lang=de-DE❭❬ should not be resolved: ${foo}.❘lang=de-DE❭❘lang=de-DE,spacing={after=140,before=0}❭""",
+                actual);
     }
 
     public record Name(String name) {

--- a/engine/src/test/java/pro/verron/officestamper/test/PlaceholderReplacementInTextBoxesTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/PlaceholderReplacementInTextBoxesTest.java
@@ -2,35 +2,34 @@ package pro.verron.officestamper.test;
 
 import org.docx4j.dml.wordprocessingDrawing.Anchor;
 import org.junit.jupiter.api.Test;
-import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 
-import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static pro.verron.officestamper.test.DefaultTests.getResource;
+import static pro.verron.officestamper.preset.OfficeStamperConfigurations.standard;
+import static pro.verron.officestamper.test.TestUtils.getResource;
+
 
 /**
  * @author Joseph Verron
  * @author Thomas Oster
  */
 class PlaceholderReplacementInTextBoxesTest {
-	@Test
+    @Test
     void expressionReplacementInTextBoxesTest() {
-		var context = new Name("Bart Simpson");
-		var template = getResource(Path.of("ExpressionReplacementInTextBoxesTest" +
-										   ".docx"));
-		var configuration = OfficeStamperConfigurations.standard()
-				.setFailOnUnresolvedExpression(false);
-		var stamper = new TestDocxStamper<Name>(configuration);
-		var actual = stamper.stampAndLoadAndExtract(template, context, Anchor.class);
-		List<String> expected = List.of(
-				"❬Bart Simpson❘color=auto❭",
-				"❬${foo}❘color=auto❭"
-		);
-		assertIterableEquals(expected, actual);
-	}
+        var context = new Name("Bart Simpson");
+        var template = getResource("ExpressionReplacementInTextBoxesTest.docx");
+        var configuration = standard()
+                .setFailOnUnresolvedExpression(false);
+        var stamper = new TestDocxStamper<Name>(configuration);
+        var actual = stamper.stampAndLoadAndExtract(template, context, Anchor.class);
+        List<String> expected = List.of(
+                "❬Bart Simpson❘color=auto❭",
+                "❬${foo}❘color=auto❭"
+        );
+        assertIterableEquals(expected, actual);
+    }
 
-	public record Name(String name) {
-	}
+    public record Name(String name) {
+    }
 }

--- a/engine/src/test/java/pro/verron/officestamper/test/RepeatDocPartBadPlaceholderTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/RepeatDocPartBadPlaceholderTest.java
@@ -9,13 +9,12 @@ import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 import pro.verron.officestamper.test.Contexts.Characters;
 import pro.verron.officestamper.test.Contexts.Role;
 
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static pro.verron.officestamper.test.DefaultTests.getResource;
+import static pro.verron.officestamper.test.TestUtils.getResource;
 
 /**
  * @author Jenei Attila
@@ -30,7 +29,7 @@ public class RepeatDocPartBadPlaceholderTest {
     @Test
     @Timeout(10) // in the case of pipe lock because of unknown exceptions
     public void testBadExpressionShouldNotBlockCallerThread() {
-        var template = getResource(Path.of("RepeatDocPartBadExpressionTest.docx"));
+        var template = getResource("RepeatDocPartBadExpressionTest.docx");
         var context = new Characters(
                 List.of(new Role("Homer Simpson", "Dan Castellaneta"),
                         new Role("Marge Simpson", "Julie Kavner"),
@@ -44,10 +43,10 @@ public class RepeatDocPartBadPlaceholderTest {
 
         String expectedErrorInfo = "someUnknownField";
         var findDirectInfo = exception.getMessage()
-                .contains(expectedErrorInfo);
+                                      .contains(expectedErrorInfo);
         var findSuppressedInfo = Arrays.stream(exception.getSuppressed())
-                .map(Throwable::getMessage)
-                .anyMatch(s -> s.contains(expectedErrorInfo));
+                                       .map(Throwable::getMessage)
+                                       .anyMatch(s -> s.contains(expectedErrorInfo));
 
         logger.info("Here is the exception info dump:", exception);
         String errorMessage = "Could not find the expected '%s' information"

--- a/engine/src/test/java/pro/verron/officestamper/test/SpelInjectionTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/SpelInjectionTest.java
@@ -5,11 +5,11 @@ import pro.verron.officestamper.api.OfficeStamperException;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 
 import java.io.IOException;
-import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static pro.verron.officestamper.test.DefaultTests.getResource;
+import static pro.verron.officestamper.test.TestUtils.getResource;
+
 
 /**
  * @author Joseph Verron
@@ -17,14 +17,15 @@ import static pro.verron.officestamper.test.DefaultTests.getResource;
 class SpelInjectionTest {
 
     @Test
-    void spelInjectionTest() throws IOException {
+    void spelInjectionTest()
+            throws IOException {
         var context = Contexts.empty();
-        try (var template = getResource(Path.of("SpelInjectionTest.docx"))) {
+        try (var template = getResource("SpelInjectionTest.docx")) {
             var configuration = OfficeStamperConfigurations.standard();
             var stamper = new TestDocxStamper<>(configuration);
-            assertThrows(OfficeStamperException.class,
-                         () -> stamper.stampAndLoadAndExtract(template,
-                                                              context));
+            assertThrows(
+                    OfficeStamperException.class,
+                    () -> stamper.stampAndLoadAndExtract(template, context));
         }
         assertDoesNotThrow(() -> "Does not throw", "Since VM is still up.");
     }

--- a/engine/src/test/java/pro/verron/officestamper/test/StampTableTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/StampTableTest.java
@@ -3,11 +3,11 @@ package pro.verron.officestamper.test;
 import org.junit.jupiter.api.Test;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 
-import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static pro.verron.officestamper.test.DefaultTests.getResource;
+import static pro.verron.officestamper.test.TestUtils.getResource;
+
 
 /**
  * A test class that verifies that stampTable feature works correctly
@@ -16,8 +16,7 @@ class StampTableTest {
 
     @Test
     void stampTableTest() {
-
-        var testDocx = getResource(Path.of("StampTableTest.docx"));
+        var testDocx = getResource("StampTableTest.docx");
 
         var configuration = OfficeStamperConfigurations.standard();
         var stamper = new TestDocxStamper<>(configuration);
@@ -37,24 +36,24 @@ class StampTableTest {
                 )
         );
         assertEquals("""
-                             Stamping Table
-                             List of Simpsons characters
-                             Character
-                             Actor
-                             Homer Simpson
-                             Dan Castellaneta
-                             Marge Simpson
-                             Julie Kavner
-                             Bart Simpson
-                             Nancy Cartwright
-                             Kent Brockman
-                             Harry Shearer
-                             Disco Stu
-                             Hank Azaria
-                             Krusty the Clown
-                             Dan Castellaneta
-                                                          
-                             There are 6 characters in the above table.""",
-                     string);
+                        Stamping Table
+                        List of Simpsons characters
+                        Character
+                        Actor
+                        Homer Simpson
+                        Dan Castellaneta
+                        Marge Simpson
+                        Julie Kavner
+                        Bart Simpson
+                        Nancy Cartwright
+                        Kent Brockman
+                        Harry Shearer
+                        Disco Stu
+                        Hank Azaria
+                        Krusty the Clown
+                        Dan Castellaneta
+                                                
+                        There are 6 characters in the above table.""",
+                string);
     }
 }

--- a/engine/src/test/java/pro/verron/officestamper/test/TestUtils.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/TestUtils.java
@@ -1,0 +1,44 @@
+package pro.verron.officestamper.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+
+/**
+ * A utility class for testing.
+ * Provides methods for retrieving InputStreams from specified resource paths.
+ * Typically used for accessing test resources.
+ */
+public class TestUtils {
+
+    /**
+     * Retrieves an InputStream for the specified resource path.
+     *
+     * @param path the path of the resource
+     *
+     * @return an InputStream for the specified resource
+     */
+    public static InputStream getResource(String path) {
+        return getResource(Path.of(path));
+    }
+
+
+    /**
+     * Retrieves an InputStream for the specified resource path.
+     *
+     * @param path the path of the resource
+     *
+     * @return an InputStream for the specified resource
+     */
+    public static InputStream getResource(Path path) {
+        try {
+            var testRoot = Path.of("..", "test", "sources");
+            var resolve = testRoot.resolve(path);
+            return Files.newInputStream(resolve);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Modified the resource retrieval process in various test classes from using Files.newInputStream or getResource method from DefaultTests to using the getResource method from TestUtils. This revision not only simplifies the code but also makes the resource retrieval process more modular and easy to manage.