### PR TITLE
Add 'engine' and 'examples' modules to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,4 +7,8 @@
     <artifactId>office-stamper</artifactId>
     <version>1.6.8</version>
     <packaging>pom</packaging>
+    <modules>
+        <module>engine</module>
+        <module>examples</module>
+    </modules>
 </project>


### PR DESCRIPTION
The pom.xml has been updated to include 'engine' and 'examples' as submodules. This change helps in the full project's components in one command.