### PR TITLE
BREAKING CHANGE: Refactor DocxStamper class to new package

### DIFF
--- a/engine/src/main/java/module-info.java
+++ b/engine/src/main/java/module-info.java
@@ -64,4 +64,5 @@ module pro.verron.officestamper {
     exports org.wickedsource.docxstamper.util;
     exports org.wickedsource.docxstamper.processor;
     exports org.wickedsource.docxstamper.processor.table;
+
 }

--- a/engine/src/main/java/org/wickedsource/docxstamper/DocxStamperConfiguration.java
+++ b/engine/src/main/java/org/wickedsource/docxstamper/DocxStamperConfiguration.java
@@ -12,6 +12,7 @@ import org.wickedsource.docxstamper.processor.repeat.IRepeatProcessor;
 import org.wickedsource.docxstamper.processor.replaceExpression.IReplaceWithProcessor;
 import org.wickedsource.docxstamper.processor.table.ITableResolver;
 import pro.verron.officestamper.api.*;
+import pro.verron.officestamper.core.DocxStamper;
 import pro.verron.officestamper.preset.CommentProcessorFactory;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 import pro.verron.officestamper.preset.Resolvers;

--- a/engine/src/main/java/org/wickedsource/docxstamper/processor/BaseCommentProcessor.java
+++ b/engine/src/main/java/org/wickedsource/docxstamper/processor/BaseCommentProcessor.java
@@ -1,8 +1,8 @@
 package org.wickedsource.docxstamper.processor;
 
-import org.wickedsource.docxstamper.DocxStamper;
 import pro.verron.officestamper.api.AbstractCommentProcessor;
 import pro.verron.officestamper.api.ParagraphPlaceholderReplacer;
+import pro.verron.officestamper.core.DocxStamper;
 
 /**
  * Base class for comment processors. The current run and paragraph are set by the {@link DocxStamper} class.

--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
@@ -1,4 +1,4 @@
-package org.wickedsource.docxstamper;
+package pro.verron.officestamper.core;
 
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
@@ -10,9 +10,6 @@ import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.el.StandardMethodResolver;
 import org.wickedsource.docxstamper.processor.CommentProcessorRegistry;
 import pro.verron.officestamper.api.*;
-import pro.verron.officestamper.core.ObjectResolverRegistry;
-import pro.verron.officestamper.core.PlaceholderReplacer;
-import pro.verron.officestamper.core.Placeholders;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 import pro.verron.officestamper.preset.OfficeStampers;
 
@@ -40,7 +37,6 @@ import java.util.function.Function;
  * It is recommended to use the {@link OfficeStampers} methods instead.
  * This class will not be exported in the future releases of the module.
  */
-@Deprecated(since = "1.6.8", forRemoval = true)
 public class DocxStamper<T>
         implements OfficeStamper<WordprocessingMLPackage> {
     private final List<PreProcessor> preprocessors;

--- a/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
@@ -1,7 +1,6 @@
 package pro.verron.officestamper.preset;
 
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
-import org.wickedsource.docxstamper.DocxStamper;
 import org.wickedsource.docxstamper.processor.displayif.DisplayIfProcessor;
 import org.wickedsource.docxstamper.processor.repeat.ParagraphRepeatProcessor;
 import org.wickedsource.docxstamper.processor.repeat.RepeatDocPartProcessor;
@@ -12,6 +11,7 @@ import pro.verron.officestamper.api.CommentProcessor;
 import pro.verron.officestamper.api.OfficeStamper;
 import pro.verron.officestamper.api.OfficeStamperConfiguration;
 import pro.verron.officestamper.api.ParagraphPlaceholderReplacer;
+import pro.verron.officestamper.core.DocxStamper;
 import pro.verron.officestamper.core.PlaceholderReplacer;
 
 /**

--- a/engine/src/main/java/pro/verron/officestamper/preset/OfficeStampers.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/OfficeStampers.java
@@ -2,12 +2,12 @@ package pro.verron.officestamper.preset;
 
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
-import org.wickedsource.docxstamper.DocxStamper;
 import org.wickedsource.docxstamper.preprocessor.MergeSameStyleRuns;
 import org.wickedsource.docxstamper.preprocessor.RemoveProofErrors;
 import pro.verron.officestamper.api.OfficeStamperConfiguration;
 import pro.verron.officestamper.api.OfficeStamperException;
 import pro.verron.officestamper.api.StreamStamper;
+import pro.verron.officestamper.core.DocxStamper;
 
 import java.io.InputStream;
 

--- a/examples/src/main/java/pro/verron/officestamper/Examples.java
+++ b/examples/src/main/java/pro/verron/officestamper/Examples.java
@@ -1,7 +1,5 @@
 package pro.verron.officestamper;
 
-import org.wickedsource.docxstamper.DocxStamper;
-import org.wickedsource.docxstamper.DocxStamperConfiguration;
 import pro.verron.officestamper.preset.OfficeStampers;
 
 import java.io.OutputStream;
@@ -14,38 +12,6 @@ import static pro.verron.officestamper.preset.OfficeStamperConfigurations.standa
 public class Examples {
 
     public static final Logger logger = Utils.getLogger();
-
-    public static void legacyStampDiagnostic(OutputStream outputStream) {
-        logger.info("Start of the diagnostic stamping procedure");
-
-        logger.info("Setup a map-reading able docx-stamper instance");
-        var configuration = new DocxStamperConfiguration()
-                .setEvaluationContextConfigurer(enableMapAccess());
-        var stamper = new DocxStamper<>(configuration);
-
-        logger.info("Load the internally packaged 'Diagnostic.docx' template resource");
-        var template = Utils.streamResource("Diagnostic.docx");
-
-        logger.info("""
-                Create a context with: \
-                system environment variables, \
-                jvm properties, \
-                and user preferences""");
-
-        var diagnosticMaker = new Diagnostic();
-        var context = Map.of(
-                "reportDate", diagnosticMaker.date(),
-                "reportUser", diagnosticMaker.user(),
-                "environment", diagnosticMaker.environmentVariables(),
-                "properties", diagnosticMaker.jvmProperties(),
-                "preferences", diagnosticMaker.userPreferences()
-        );
-
-        logger.info("Start stamping process");
-        stamper.stamp(template, context, outputStream);
-
-        logger.info("End of the diagnostic stamping procedure");
-    }
 
     public static void stampDiagnostic(OutputStream outputStream) {
         logger.info("Start of the diagnostic stamping procedure");

--- a/examples/src/main/java/pro/verron/officestamper/Main.java
+++ b/examples/src/main/java/pro/verron/officestamper/Main.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static pro.verron.officestamper.Examples.legacyStampDiagnostic;
 import static pro.verron.officestamper.Examples.stampDiagnostic;
 
 public class Main {
@@ -16,10 +15,6 @@ public class Main {
 
     public static void main(String[] args)
             throws Exception {
-        // Use the way prior to docx-stamper 1.6.8
-        legacyStampDiagnostic(createOutStream("LegacyDiagnostic-"));
-
-        // Use the way from docx-stamper 1.6.8 and with office-stamper
         stampDiagnostic(createOutStream("Diagnostic-"));
     }
 


### PR DESCRIPTION
The DocxStamper class has been moved from org.wickedsource.docxstamper to pro.verron.officestamper.core as per the recent refactoring plan. The import statements across all files using this class have also been adjusted accordingly. The legacy code in examples regarding the use of DocxStamper inspired diagnostic methods has been removed.