### PR TITLE
BREAKING CHANGE: Refactor and relocate DocxStamperConfiguration

### DIFF
--- a/engine/src/main/java/module-info.java
+++ b/engine/src/main/java/module-info.java
@@ -54,15 +54,14 @@ module pro.verron.officestamper {
     exports pro.verron.officestamper.experimental to pro.verron.officestamper.test;
 
     opens pro.verron.officestamper.core to pro.verron.officestamper.test;
-    exports pro.verron.officestamper.core to pro.verron.officestamper.test;
 
     // TODO_LATER: remove all the following exports in next version
     opens pro.verron.officestamper;
     exports pro.verron.officestamper;
-    exports org.wickedsource.docxstamper;
     exports org.wickedsource.docxstamper.el;
     exports org.wickedsource.docxstamper.util;
     exports org.wickedsource.docxstamper.processor;
     exports org.wickedsource.docxstamper.processor.table;
+    exports pro.verron.officestamper.core;
 
 }

--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamperConfiguration.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamperConfiguration.java
@@ -1,4 +1,4 @@
-package org.wickedsource.docxstamper;
+package pro.verron.officestamper.core;
 
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.springframework.expression.EvaluationContext;
@@ -12,7 +12,6 @@ import org.wickedsource.docxstamper.processor.repeat.IRepeatProcessor;
 import org.wickedsource.docxstamper.processor.replaceExpression.IReplaceWithProcessor;
 import org.wickedsource.docxstamper.processor.table.ITableResolver;
 import pro.verron.officestamper.api.*;
-import pro.verron.officestamper.core.DocxStamper;
 import pro.verron.officestamper.preset.CommentProcessorFactory;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 import pro.verron.officestamper.preset.Resolvers;
@@ -37,7 +36,6 @@ import java.util.function.Function;
  * {@link OfficeStamperConfiguration} interface instead.
  * This class will not be exported in the future releases of the module.
  */
-@Deprecated(since = "1.6.8", forRemoval = true)
 public class DocxStamperConfiguration
         implements OfficeStamperConfiguration {
 

--- a/engine/src/main/java/pro/verron/officestamper/preset/OfficeStamperConfigurations.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/OfficeStamperConfigurations.java
@@ -1,9 +1,9 @@
 package pro.verron.officestamper.preset;
 
-import org.wickedsource.docxstamper.DocxStamperConfiguration;
 import org.wickedsource.docxstamper.preprocessor.MergeSameStyleRuns;
 import org.wickedsource.docxstamper.preprocessor.RemoveProofErrors;
 import pro.verron.officestamper.api.OfficeStamperConfiguration;
+import pro.verron.officestamper.core.DocxStamperConfiguration;
 
 /**
  * The OfficeStamperConfigurations class provides static methods


### PR DESCRIPTION
The file DocxStamperConfiguration has been moved from org.wickedsource.docxstamper to pro.verron.officestamper.core package. Additionally, the module-info.java file has been updated to reflect these changes. Deprecated annotation is also removed from this class.