### PR TITLE
refactor!: remove deprecated methods

### DIFF
--- a/engine/src/main/java/org/wickedsource/docxstamper/processor/repeat/ParagraphRepeatProcessor.java
+++ b/engine/src/main/java/org/wickedsource/docxstamper/processor/repeat/ParagraphRepeatProcessor.java
@@ -4,19 +4,17 @@ import org.docx4j.XmlUtils;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.*;
 import org.wickedsource.docxstamper.processor.BaseCommentProcessor;
-import org.wickedsource.docxstamper.util.ParagraphUtil;
 import org.wickedsource.docxstamper.util.SectionUtil;
-import pro.verron.officestamper.api.*;
+import pro.verron.officestamper.api.Comment;
+import pro.verron.officestamper.api.CommentProcessor;
+import pro.verron.officestamper.api.OfficeStamperException;
+import pro.verron.officestamper.api.ParagraphPlaceholderReplacer;
 import pro.verron.officestamper.core.CommentUtil;
-import pro.verron.officestamper.core.PlaceholderReplacer;
 import pro.verron.officestamper.core.StandardParagraph;
-import pro.verron.officestamper.preset.Resolvers;
 
 import java.math.BigInteger;
 import java.util.*;
 import java.util.function.Supplier;
-
-import static java.util.Collections.singletonList;
 
 /**
  * This class is used to repeat paragraphs and tables.
@@ -45,28 +43,6 @@ public class ParagraphRepeatProcessor
     ) {
         super(placeholderReplacer);
         this.nullSupplier = nullSupplier;
-    }
-
-    /**
-     * <p>newInstance.</p>
-     *
-     * @param pr              replaces expressions with values
-     * @param nullReplacement replaces null values
-     *
-     * @return a new instance of ParagraphRepeatProcessor
-     *
-     * @deprecated use {@link ParagraphRepeatProcessor#newInstance(ParagraphPlaceholderReplacer)} for instantiation
-     * and {@link OfficeStamperConfiguration#addResolver(ObjectResolver)} with
-     * {@link Resolvers#nullToDefault(String)} instead
-     */
-    @Deprecated(since = "1.6.8", forRemoval = true)
-    public static CommentProcessor newInstance(
-            PlaceholderReplacer pr,
-            String nullReplacement
-    ) {
-        return new ParagraphRepeatProcessor(pr,
-                () -> singletonList(ParagraphUtil.create(
-                        nullReplacement)));
     }
 
     /**

--- a/engine/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/engine/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -7,11 +7,8 @@ import org.docx4j.wml.*;
 import org.jvnet.jaxb2_commons.ppp.Child;
 import org.wickedsource.docxstamper.processor.BaseCommentProcessor;
 import org.wickedsource.docxstamper.util.DocumentUtil;
-import org.wickedsource.docxstamper.util.ParagraphUtil;
 import org.wickedsource.docxstamper.util.SectionUtil;
 import pro.verron.officestamper.api.*;
-import pro.verron.officestamper.core.PlaceholderReplacer;
-import pro.verron.officestamper.preset.Resolvers;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -26,7 +23,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 import static org.wickedsource.docxstamper.util.DocumentUtil.walkObjectsAndImportImages;
@@ -60,31 +56,6 @@ public class RepeatDocPartProcessor
         super(placeholderReplacer);
         this.stamper = stamper;
         this.nullSupplier = nullSupplier;
-    }
-
-    /**
-     * <p>newInstance.</p>
-     *
-     * @param pr                   the placeholderReplacer
-     * @param stamper              the stamper
-     * @param nullReplacementValue the value to use when the expression
-     *                             resolves to null
-     *
-     * @return a new instance of this processor
-     *
-     * @deprecated use {@link RepeatDocPartProcessor#newInstance(ParagraphPlaceholderReplacer, OfficeStamper)} for
-     * instantiation and {@link OfficeStamperConfiguration#addResolver(ObjectResolver)} with
-     * {@link Resolvers#nullToDefault(String)} instead
-     */
-    @Deprecated(since = "1.6.8", forRemoval = true)
-    public static CommentProcessor newInstance(
-            PlaceholderReplacer pr,
-            OfficeStamper<WordprocessingMLPackage> stamper,
-            String nullReplacementValue
-    ) {
-        Supplier<List<?>> nullSupplier = () -> singletonList(
-                ParagraphUtil.create(nullReplacementValue));
-        return new RepeatDocPartProcessor(pr, stamper, nullSupplier);
     }
 
     /**

--- a/engine/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatProcessor.java
+++ b/engine/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatProcessor.java
@@ -25,32 +25,20 @@ import static java.util.Collections.emptyList;
  * @version ${version}
  * @since 1.0.0
  */
-public class RepeatProcessor extends BaseCommentProcessor implements IRepeatProcessor {
+public class RepeatProcessor
+        extends BaseCommentProcessor
+        implements IRepeatProcessor {
 
-	private final BiFunction<WordprocessingMLPackage, Tr, List<Tr>> nullSupplier;
-	private Map<Tr, List<Object>> tableRowsToRepeat = new HashMap<>();
-	private Map<Tr, Comment> tableRowsCommentsToRemove = new HashMap<>();
+    private final BiFunction<WordprocessingMLPackage, Tr, List<Tr>> nullSupplier;
+    private Map<Tr, List<Object>> tableRowsToRepeat = new HashMap<>();
+    private Map<Tr, Comment> tableRowsCommentsToRemove = new HashMap<>();
 
-	private RepeatProcessor(
-			ParagraphPlaceholderReplacer placeholderReplacer,
-			BiFunction<WordprocessingMLPackage, Tr, List<Tr>> nullSupplier1
-	) {
-		super(placeholderReplacer);
-		nullSupplier = nullSupplier1;
-	}
-
-	/**
-	 * Creates a new RepeatProcessor.
-	 *
-	 * @param pr The PlaceholderReplacer to use.
-	 * @return A new RepeatProcessor.
-	 * @deprecated since unused in core lib
-	 */
-	@Deprecated(since = "1.6.8", forRemoval = true)
-	public static CommentProcessor newInstanceWithNullReplacement(
-			PlaceholderReplacer pr
-	) {
-		return new RepeatProcessor(pr, (document, row) -> RepeatProcessor.stampEmptyContext(pr, document, row));
+    private RepeatProcessor(
+            ParagraphPlaceholderReplacer placeholderReplacer,
+            BiFunction<WordprocessingMLPackage, Tr, List<Tr>> nullSupplier1
+    ) {
+        super(placeholderReplacer);
+        nullSupplier = nullSupplier1;
     }
 
     /**
@@ -59,82 +47,89 @@ public class RepeatProcessor extends BaseCommentProcessor implements IRepeatProc
      * @param pr       The PlaceholderReplacer to use.
      * @param document a {@link WordprocessingMLPackage} object
      * @param row1     a {@link Tr} object
+     *
      * @return A new RepeatProcessor.
      */
     public static List<Tr> stampEmptyContext(PlaceholderReplacer pr, WordprocessingMLPackage document, Tr row1) {
-		Tr rowClone = XmlUtils.deepCopy(row1);
+        Tr rowClone = XmlUtils.deepCopy(row1);
         Object emptyContext = new Object();
         new ParagraphResolverDocumentWalker(rowClone, emptyContext, document, pr).walk();
         return List.of(rowClone);
-	}
+    }
 
-	/**
-	 * Creates a new RepeatProcessor.
-	 *
-	 * @param pr The PlaceholderReplacer to use.
-	 * @return A new RepeatProcessor.
-	 */
-	public static CommentProcessor newInstance(ParagraphPlaceholderReplacer pr) {
-		return new RepeatProcessor(pr, (document, row) -> emptyList());
-	}
+    /**
+     * Creates a new RepeatProcessor.
+     *
+     * @param pr The PlaceholderReplacer to use.
+     *
+     * @return A new RepeatProcessor.
+     */
+    public static CommentProcessor newInstance(ParagraphPlaceholderReplacer pr) {
+        return new RepeatProcessor(pr, (document, row) -> emptyList());
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public void commitChanges(WordprocessingMLPackage document) {
+    /** {@inheritDoc} */
+    @Override
+    public void commitChanges(WordprocessingMLPackage document) {
         repeatRows(document);
-	}
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public void reset() {
-		this.tableRowsToRepeat = new HashMap<>();
-		this.tableRowsCommentsToRemove = new HashMap<>();
-	}
+    /** {@inheritDoc} */
+    @Override
+    public void reset() {
+        this.tableRowsToRepeat = new HashMap<>();
+        this.tableRowsCommentsToRemove = new HashMap<>();
+    }
 
-	private void repeatRows(final WordprocessingMLPackage document) {
-		for (Map.Entry<Tr, List<Object>> entry : tableRowsToRepeat.entrySet()) {
-			Tr row = entry.getKey();
-			List<Object> expressionContexts = entry.getValue();
+    private void repeatRows(final WordprocessingMLPackage document) {
+        for (Map.Entry<Tr, List<Object>> entry : tableRowsToRepeat.entrySet()) {
+            Tr row = entry.getKey();
+            List<Object> expressionContexts = entry.getValue();
 
-			Tbl table = (Tbl) XmlUtils.unwrap(row.getParent());
-			int index = table.getContent().indexOf(row);
+            Tbl table = (Tbl) XmlUtils.unwrap(row.getParent());
+            int index = table.getContent()
+                             .indexOf(row);
 
 
-			List<Tr> changes;
-			if (expressionContexts == null) {
-				changes = nullSupplier.apply(document, row);
-			} else {
-				changes = new ArrayList<>();
-				for (Object expressionContext : expressionContexts) {
-					Tr rowClone = XmlUtils.deepCopy(row);
-					Comment commentWrapper = Objects.requireNonNull(
-							tableRowsCommentsToRemove.get(row));
-					Comments.Comment comment = Objects.requireNonNull(commentWrapper.getComment());
-					BigInteger commentId = comment.getId();
-					CommentUtil.deleteCommentFromElements(rowClone.getContent(), commentId);
-					new ParagraphResolverDocumentWalker(rowClone,
-														expressionContext,
-														document,
-														this.placeholderReplacer).walk();
-					changes.add(rowClone);
-				}
-			}
-			table.getContent().addAll(index + 1, changes);
-			table.getContent().remove(row);
-		}
-	}
+            List<Tr> changes;
+            if (expressionContexts == null) {
+                changes = nullSupplier.apply(document, row);
+            }
+            else {
+                changes = new ArrayList<>();
+                for (Object expressionContext : expressionContexts) {
+                    Tr rowClone = XmlUtils.deepCopy(row);
+                    Comment commentWrapper = Objects.requireNonNull(
+                            tableRowsCommentsToRemove.get(row));
+                    Comments.Comment comment = Objects.requireNonNull(commentWrapper.getComment());
+                    BigInteger commentId = comment.getId();
+                    CommentUtil.deleteCommentFromElements(rowClone.getContent(), commentId);
+                    new ParagraphResolverDocumentWalker(rowClone,
+                            expressionContext,
+                            document,
+                            this.placeholderReplacer).walk();
+                    changes.add(rowClone);
+                }
+            }
+            table.getContent()
+                 .addAll(index + 1, changes);
+            table.getContent()
+                 .remove(row);
+        }
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public void repeatTableRow(List<Object> objects) {
-		P pCoords = getParagraph();
+    /** {@inheritDoc} */
+    @Override
+    public void repeatTableRow(List<Object> objects) {
+        P pCoords = getParagraph();
 
-		if (pCoords.getParent() instanceof Tc tc
-				&& tc.getParent() instanceof Tr tableRow) {
-			tableRowsToRepeat.put(tableRow, objects);
-			tableRowsCommentsToRemove.put(tableRow, getCurrentCommentWrapper());
-		} else {
-			throw new CommentProcessingException("Paragraph is not within a table!", pCoords);
-		}
-	}
+        if (pCoords.getParent() instanceof Tc tc
+                && tc.getParent() instanceof Tr tableRow) {
+            tableRowsToRepeat.put(tableRow, objects);
+            tableRowsCommentsToRemove.put(tableRow, getCurrentCommentWrapper());
+        }
+        else {
+            throw new CommentProcessingException("Paragraph is not within a table!", pCoords);
+        }
+    }
 }


### PR DESCRIPTION
Adjusted code formatting for consistency and readability across multiple classes. Removed deprecated methods in RepeatProcessor, RepeatDocPartProcessor, and ParagraphRepeatProcessor classes, as they are no longer being used in the core library. This simplifies the codebase and reduces potential points of failure.