### PR TITLE
refactor!: Remove deprecated setDocument method from CommentProcessor

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/api/AbstractCommentProcessor.java
+++ b/engine/src/main/java/pro/verron/officestamper/api/AbstractCommentProcessor.java
@@ -1,6 +1,5 @@
 package pro.verron.officestamper.api;
 
-import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.P;
 import org.docx4j.wml.R;
 
@@ -20,7 +19,6 @@ public abstract class AbstractCommentProcessor
     private P paragraph;
     private R currentRun;
     private Comment currentComment;
-    private WordprocessingMLPackage document;
 
     /**
      * Creates an instance of AbstractCommentProcessor with the given ParagraphPlaceholderReplacer.
@@ -82,29 +80,5 @@ public abstract class AbstractCommentProcessor
     @Override
     public void setCurrentRun(R run) {
         this.currentRun = run;
-    }
-
-    /**
-     * <p>Getter for the field <code>document</code>.</p>
-     *
-     * @return a {@link WordprocessingMLPackage} object
-     * @deprecated the document is passed to the processor through the commitChange method now
-     * and will probably pe passed through the constructor in the future
-     */
-    @Deprecated(since = "1.6.5", forRemoval = true)
-    public WordprocessingMLPackage getDocument() {
-        return document;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated the document is passed to the processor through the commitChange method now,
-     * and will probably pe passed through the constructor in the future
-     */
-    @Deprecated(since = "1.6.5", forRemoval = true)
-    @Override
-    public void setDocument(WordprocessingMLPackage document) {
-        this.document = document;
     }
 }

--- a/engine/src/main/java/pro/verron/officestamper/api/CommentProcessor.java
+++ b/engine/src/main/java/pro/verron/officestamper/api/CommentProcessor.java
@@ -49,19 +49,6 @@ public interface CommentProcessor {
     void setCurrentCommentWrapper(Comment comment);
 
     /**
-     * Passes the processed document, to make all linked data
-     * (images, etc.) available
-     * to processors that need it (example: repeatDocPart)
-     *
-     * @param document DocX template being processed.
-     * @deprecated the document is passed to the processor through the commitChange method now,
-     * and will probably pe passed through the constructor in the future
-     */
-
-    @Deprecated(since = "1.6.5", forRemoval = true)
-    void setDocument(WordprocessingMLPackage document);
-
-    /**
      * Resets all states in the comment processor so that it can be re-used in another stamping process.
      */
     void reset();

--- a/engine/src/test/java/pro/verron/officestamper/test/CustomCommentProcessor.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/CustomCommentProcessor.java
@@ -102,14 +102,6 @@ public class CustomCommentProcessor
     /**
      * {@inheritDoc}
      */
-    @Deprecated(since = "1.6.5", forRemoval = true)
-    @Override
-    public void setDocument(WordprocessingMLPackage document) {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void visitParagraph() {
         visitedParagraphs.add(currentParagraph);


### PR DESCRIPTION
The setDocument method in CommentProcessor and related classes has been removed as it is no longer necessary. The document is now passed through the commitChange method or the constructor. This change simplifies the code and removes the need for deprecated methods.