### PR TITLE
refactor!: Remove deprecated methods in Comment and StandardComment

### DIFF
--- a/engine/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/engine/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -2,6 +2,7 @@ package org.wickedsource.docxstamper.processor.repeat;
 
 import org.docx4j.jaxb.Context;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
+import org.docx4j.openpackaging.exceptions.InvalidFormatException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.*;
 import org.jvnet.jaxb2_commons.ppp.Child;
@@ -9,6 +10,7 @@ import org.wickedsource.docxstamper.processor.BaseCommentProcessor;
 import org.wickedsource.docxstamper.util.DocumentUtil;
 import org.wickedsource.docxstamper.util.SectionUtil;
 import pro.verron.officestamper.api.*;
+import pro.verron.officestamper.core.CommentUtil;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -168,7 +170,13 @@ public class RepeatDocPartProcessor
             var expressionContexts = entry.getValue();
             var gcp = requireNonNull(comment.getParent());
             var repeatElements = comment.getElements();
-            var subTemplate = comment.tryBuildingSubtemplate(document);
+            WordprocessingMLPackage subTemplate = null;
+            //TODO: fix that explicit exception more sneakily
+            try {
+                subTemplate = CommentUtil.createSubWordDocument(comment);
+            } catch (InvalidFormatException e) {
+                throw new RuntimeException(e);
+            }
             SectPr previousSectionBreak = SectionUtil.getPreviousSectionBreakIfPresent(
                     repeatElements.get(0), gcp);
             boolean oddNumberOfBreaks = SectionUtil.isOddNumberOfSectionBreaks(

--- a/engine/src/main/java/pro/verron/officestamper/api/Comment.java
+++ b/engine/src/main/java/pro/verron/officestamper/api/Comment.java
@@ -2,7 +2,6 @@ package pro.verron.officestamper.api;
 
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.*;
-import pro.verron.officestamper.core.CommentUtil;
 
 import java.util.List;
 import java.util.Set;
@@ -23,44 +22,8 @@ public interface Comment {
      * Retrieves the elements in the document that are between the comment range anchors.
      *
      * @return a list of objects representing the elements between the comment range anchors.
-     * @deprecated removed for replacement by {@link Comment#getElements()} which doesn't imply a specific usage
-     */
-    @Deprecated(since = "1.6.8", forRemoval = true)
-    default List<Object> getRepeatElements() {
-        return getElements();
-    }
-
-    /**
-     * Retrieves the elements in the document that are between the comment range anchors.
-     *
-     * @return a list of objects representing the elements between the comment range anchors.
      */
     List<Object> getElements();
-
-    /**
-     * Creates a new document containing only the elements between the comment range anchors.
-     *
-     * @param document the document from which to copy the elements.
-     *
-     * @return a new document containing only the elements between the comment range anchors.
-     *
-     * @throws Exception if the sub template could not be created.
-     * @deprecated use {@link CommentUtil#createSubWordDocument(Comment)} instead
-     */
-    @Deprecated(since = "1.6.8", forRemoval = true)
-    WordprocessingMLPackage getSubTemplate(WordprocessingMLPackage document)
-            throws Exception;
-
-    /**
-     * Tries to build a subtemplate from the given WordprocessingMLPackage document.
-     *
-     * @param document the source document from which to build the subtemplate
-     *
-     * @return the built subtemplate as a WordprocessingMLPackage
-     * @deprecated use {@link CommentUtil#createSubWordDocument(Comment)} instead
-     */
-    @Deprecated(since = "1.6.8", forRemoval = true)
-    WordprocessingMLPackage tryBuildingSubtemplate(WordprocessingMLPackage document);
 
     /**
      * Retrieves the {@link CommentRangeEnd} object associated with this comment.

--- a/engine/src/main/java/pro/verron/officestamper/core/StandardComment.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/StandardComment.java
@@ -8,7 +8,6 @@ import org.docx4j.wml.ContentAccessor;
 import org.docx4j.wml.R.CommentReference;
 import org.wickedsource.docxstamper.util.DocumentUtil;
 import pro.verron.officestamper.api.Comment;
-import pro.verron.officestamper.api.OfficeStamperException;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -67,45 +66,6 @@ public class StandardComment
             endFound = endFound || DocumentUtil.depthElementSearch(getCommentRangeEnd(), element);
         }
         return elements;
-    }
-
-    /**
-     * Creates a new document containing only the elements between the comment range anchors.
-     *
-     * @param document the document from which to copy the elements.
-     *
-     * @return a new document containing only the elements between the comment range anchors.
-     *
-     * @throws Exception if the sub template could not be created.
-     * @deprecated use {@link CommentUtil#createSubWordDocument(Comment)} instead
-     */
-    @Deprecated(since = "1.6.8", forRemoval = true)
-    @Override
-    public WordprocessingMLPackage getSubTemplate(WordprocessingMLPackage document)
-            throws Exception {
-        return CommentUtil.createSubWordDocument(this);
-    }
-
-    /**
-     * Creates a new document containing only the elements between the comment range anchors.
-     * If the sub template could not be created, a
-     * {@link OfficeStamperException} is thrown.
-     *
-     * @param document the document from which to copy the elements.
-     *
-     * @return a new document containing only the elements between the comment range anchors.
-     * @deprecated use {@link CommentUtil#createSubWordDocument(Comment)} instead
-     */
-    @Deprecated(since = "1.6.8", forRemoval = true)
-    @Override
-    public WordprocessingMLPackage tryBuildingSubtemplate(
-            WordprocessingMLPackage document
-    ) {
-        try {
-            return getSubTemplate(document);
-        } catch (Exception e) {
-            throw new OfficeStamperException(e);
-        }
     }
 
     /**


### PR DESCRIPTION
Deprecated methods in Comment and StandardComment classes have been removed, which were related to sub-template creation. The functionality to create sub-templates has been transferred to CommentUtil#createSubWordDocument() for better structural organization and improved readability. Updates were also made in the RepeatDocPartProcessor class to use this new approach.