### PR TITLE
refactor!: Remove deprecated build method from OfficeStamperConfigura…

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/api/OfficeStamperConfiguration.java
+++ b/engine/src/main/java/pro/verron/officestamper/api/OfficeStamperConfiguration.java
@@ -1,6 +1,5 @@
 package pro.verron.officestamper.api;
 
-import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.springframework.expression.spel.SpelParserConfiguration;
 
 import java.util.List;
@@ -87,17 +86,6 @@ public interface OfficeStamperConfiguration {
             Class<?> interfaceClass,
             Function<ParagraphPlaceholderReplacer, CommentProcessor> commentProcessorFactory
     );
-
-    /**
-     * Retrieves the OfficeStamper configured with the current settings.
-     *
-     * @return the OfficeStamper configured with the current settings.
-     *
-     * @since 1.6.4
-     * @deprecated This method is marked for removal and should not be used. Consider using a different method instead.
-     */
-    @Deprecated(forRemoval = true, since = "1.6.4")
-    OfficeStamper<WordprocessingMLPackage> build();
 
     /**
      * Adds a pre-processor to the OfficeStamperConfiguration. A pre-processor is responsible for


### PR DESCRIPTION
…tion

The deprecated build method in OfficeStamperConfiguration class has been removed. This action was taken due to marking the method for removal in previous versions. Users should consider using different methods instead of this deprecated one.