### PR TITLE
Remove deprecated methods and updates

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/core/CommentUtil.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/CommentUtil.java
@@ -127,27 +127,6 @@ public class CommentUtil {
     }
 
     /**
-     * Returns the comment string for the given DOCX4J object and document.
-     *
-     * @param object   the DOCX4J object whose comment to retrieve.
-     * @param document the document that contains the object.
-     *
-     * @return an Expression representing the comment string.
-     *
-     * @throws OfficeStamperException if an error occurs while retrieving the comment.
-     * @deprecated This method's been deprecated since version 1.6.8
-     * and will be removed in the future.
-     */
-    @Deprecated(since = "1.6.8", forRemoval = true)
-    public static Placeholder getCommentStringFor(
-            ContentAccessor object, WordprocessingMLPackage document
-    ) {
-        var comment = getCommentFor(object, document)
-                .orElseThrow(OfficeStamperException::new);
-        return getCommentString(comment);
-    }
-
-    /**
      * Returns the first comment found for the given docx object. Note that an object is
      * only considered commented if the comment STARTS within the object. Comments
      * spanning several objects are not supported by this method.

--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
@@ -10,7 +10,6 @@ import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.el.StandardMethodResolver;
 import org.wickedsource.docxstamper.processor.CommentProcessorRegistry;
 import pro.verron.officestamper.api.*;
-import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 import pro.verron.officestamper.preset.OfficeStampers;
 
 import java.io.InputStream;
@@ -42,16 +41,6 @@ public class DocxStamper<T>
     private final List<PreProcessor> preprocessors;
     private final PlaceholderReplacer placeholderReplacer;
     private final CommentProcessorRegistry commentProcessorRegistry;
-
-    /**
-     * Creates a new DocxStamper with the default configuration.
-     *
-     * @deprecated since 1.6.4, use {@link OfficeStampers#docxStamper()} instead.
-     */
-    @Deprecated(since = "1.6.4", forRemoval = true)
-    public DocxStamper() {
-        this(OfficeStamperConfigurations.standard());
-    }
 
     /**
      * Creates a new DocxStamper with the given configuration.

--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamperConfiguration.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamperConfiguration.java
@@ -1,6 +1,5 @@
 package pro.verron.officestamper.core;
 
-import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.SpelParserConfiguration;
 import org.springframework.lang.NonNull;
@@ -179,19 +178,6 @@ public class DocxStamperConfiguration
     ) {
         this.commentProcessors.put(interfaceClass, commentProcessorFactory);
         return this;
-    }
-
-    /**
-     * Creates a {@link DocxStamper} instance configured with this configuration.
-     *
-     * @return a {@link DocxStamper} object
-     *
-     * @deprecated use new {@link DocxStamper#DocxStamper(OfficeStamperConfiguration)}} instead
-     */
-    @Override
-    @Deprecated(forRemoval = true, since = "1.6.4")
-    public OfficeStamper<WordprocessingMLPackage> build() {
-        return new DocxStamper<>(this);
     }
 
     /**

--- a/engine/src/main/java/pro/verron/officestamper/preset/Resolvers.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/Resolvers.java
@@ -396,10 +396,8 @@ public class Resolvers {
      * @author Joseph Verron
      * @version ${version}
      * @since 1.6.7
-     * @deprecated will not be removed, but will be made package-private
      */
-    @Deprecated(since = "1.6.7")
-    public static class Null2DefaultResolver
+    private static class Null2DefaultResolver
             implements ObjectResolver {
 
         private final String text;


### PR DESCRIPTION
This commit removes several methods previously marked as deprecated across various classes. It also changed the visibility of Null2DefaultResolver from public to private in the Resolvers class. This ensures a cleaner code base and encourages usage of up-to-date methods and configurations.