### PR TITLE
refactor: Remove deprecated annotations from DocxStamper classes

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
@@ -10,7 +10,6 @@ import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.el.StandardMethodResolver;
 import org.wickedsource.docxstamper.processor.CommentProcessorRegistry;
 import pro.verron.officestamper.api.*;
-import pro.verron.officestamper.preset.OfficeStampers;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -29,12 +28,6 @@ import java.util.function.Function;
  * @author Joseph Verron
  * @version ${version}
  * @since 1.0.0
- * @deprecated since 1.6.8, This class has been deprecated in the effort
- * of the library modularization, because it
- * exposes too many implementation details to library users, and makes it
- * hard to extend the library comfortably.
- * It is recommended to use the {@link OfficeStampers} methods instead.
- * This class will not be exported in the future releases of the module.
  */
 public class DocxStamper<T>
         implements OfficeStamper<WordprocessingMLPackage> {

--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamperConfiguration.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamperConfiguration.java
@@ -12,7 +12,6 @@ import org.wickedsource.docxstamper.processor.replaceExpression.IReplaceWithProc
 import org.wickedsource.docxstamper.processor.table.ITableResolver;
 import pro.verron.officestamper.api.*;
 import pro.verron.officestamper.preset.CommentProcessorFactory;
-import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 import pro.verron.officestamper.preset.Resolvers;
 
 import java.util.ArrayList;
@@ -30,13 +29,6 @@ import java.util.function.Function;
  * @author Tom Hombergs
  * @version ${version}
  * @since 1.0.3
- * @deprecated since 1.6.8, This class has been deprecated in the effort
- * of the library modularization, because it
- * exposes too many implementation details to library users, and makes it
- * hard to extend the library comfortably.
- * It is recommended to use the  {@link OfficeStamperConfigurations#standard()} method and
- * {@link OfficeStamperConfiguration} interface instead.
- * This class will not be exported in the future releases of the module.
  */
 public class DocxStamperConfiguration
         implements OfficeStamperConfiguration {


### PR DESCRIPTION
The deprecated annotations and comments have been removed from the DocxStamperConfiguration and DocxStamper classes. This change simplifies the code and removes outdated information that could potentially confuse users.