### PR TITLE
refactor!: Remove generic typing from DocxStamper class

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
@@ -23,13 +23,12 @@ import java.util.function.Function;
  * interface that is used to stamp DOCX templates with a context object and
  * write the result to an output stream.
  *
- * @param <T> The type of the context that can be stamped
  * @author Tom Hombergs
  * @author Joseph Verron
  * @version ${version}
  * @since 1.0.0
  */
-public class DocxStamper<T>
+public class DocxStamper
         implements OfficeStamper<WordprocessingMLPackage> {
     private final List<PreProcessor> preprocessors;
     private final PlaceholderReplacer placeholderReplacer;

--- a/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
@@ -54,7 +54,7 @@ public class CommentProcessorFactory {
 	}
 
 	private OfficeStamper<WordprocessingMLPackage> getStamper() {
-		return (template, context, output) -> new DocxStamper<>(configuration).stamp(template, context, output);
+		return (template, context, output) -> new DocxStamper(configuration).stamp(template, context, output);
 	}
 
 	/**

--- a/engine/src/main/java/pro/verron/officestamper/preset/OfficeStampers.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/OfficeStampers.java
@@ -44,7 +44,7 @@ public class OfficeStampers {
     ) {
         return new StreamStamper<>(
                 OfficeStampers::loadWord,
-                new DocxStamper<Object>(config)
+                new DocxStamper(config)
         );
     }
 


### PR DESCRIPTION
The DocxStamper class is refactored to remove the generic type. This change has been reflected in the related classes and methods that use this class, such as CommentProcessorFactory and OfficeStampers, by creating new instances of DocxStamper without type specification.