### PR TITLE
refactor!: CommentProcessorRegistry class location and update module …

### DIFF
--- a/engine/src/main/java/module-info.java
+++ b/engine/src/main/java/module-info.java
@@ -58,7 +58,6 @@ module pro.verron.officestamper {
     // TODO_LATER: remove all the following exports in next version
     exports org.wickedsource.docxstamper.el;
     exports org.wickedsource.docxstamper.util;
-    exports org.wickedsource.docxstamper.processor;
     exports org.wickedsource.docxstamper.processor.table;
     exports pro.verron.officestamper.core;
 

--- a/engine/src/main/java/pro/verron/officestamper/core/CommentProcessorRegistry.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/CommentProcessorRegistry.java
@@ -1,4 +1,4 @@
-package org.wickedsource.docxstamper.processor;
+package pro.verron.officestamper.core;
 
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.Comments;
@@ -15,9 +15,6 @@ import org.wickedsource.docxstamper.util.walk.BaseCoordinatesWalker;
 import pro.verron.officestamper.api.Comment;
 import pro.verron.officestamper.api.CommentProcessor;
 import pro.verron.officestamper.api.OfficeStamperException;
-import pro.verron.officestamper.core.CommentUtil;
-import pro.verron.officestamper.core.Placeholders;
-import pro.verron.officestamper.core.StandardParagraph;
 
 import java.math.BigInteger;
 import java.util.ArrayList;

--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
@@ -8,7 +8,6 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.lang.NonNull;
 import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.el.StandardMethodResolver;
-import org.wickedsource.docxstamper.processor.CommentProcessorRegistry;
 import pro.verron.officestamper.api.*;
 
 import java.io.InputStream;


### PR DESCRIPTION
…exports

The CommentProcessorRegistry class has been moved from the org.wickedsource.docxstamper.processor package to the pro.verron.officestamper.core package. The relevant exports in module-info have been updated to reflect this reorganization of code for better package structure and separation of concerns. Moreover, unnecessary import statements have been removed, thus, keep the code clean and concise.