### PR TITLE
refactor!: Moved classes from 'core.expression' to 'core' package

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/core/Matcher.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/Matcher.java
@@ -1,4 +1,4 @@
-package pro.verron.officestamper.core.expression;
+package pro.verron.officestamper.core;
 
 
 /**

--- a/engine/src/main/java/pro/verron/officestamper/core/PlaceholderFinder.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/PlaceholderFinder.java
@@ -1,7 +1,6 @@
-package pro.verron.officestamper.core.expression;
+package pro.verron.officestamper.core;
 
 import pro.verron.officestamper.api.Placeholder;
-import pro.verron.officestamper.core.StandardPlaceholder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/engine/src/main/java/pro/verron/officestamper/core/Placeholders.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/Placeholders.java
@@ -3,8 +3,6 @@ package pro.verron.officestamper.core;
 import pro.verron.officestamper.api.OfficeStamperException;
 import pro.verron.officestamper.api.Paragraph;
 import pro.verron.officestamper.api.Placeholder;
-import pro.verron.officestamper.core.expression.Matcher;
-import pro.verron.officestamper.core.expression.PlaceholderFinder;
 
 import java.util.List;
 import java.util.regex.Pattern;

--- a/engine/src/main/java/pro/verron/officestamper/core/StandardPlaceholder.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/StandardPlaceholder.java
@@ -1,7 +1,6 @@
 package pro.verron.officestamper.core;
 
 import pro.verron.officestamper.api.Placeholder;
-import pro.verron.officestamper.core.expression.Matcher;
 
 /**
  * Represents an expression with a configured Matcher.

--- a/engine/src/main/java/pro/verron/officestamper/core/expression/package-info.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/expression/package-info.java
@@ -1,4 +1,0 @@
-@NonNullApi
-package pro.verron.officestamper.core.expression;
-
-import org.springframework.lang.NonNullApi;


### PR DESCRIPTION
The PlaceholderFinder and Matcher classes which were previously located in the 'core.expression' package have been moved to the 'core' package. The 'core.expression' package has subsequently been deleted. This refactoring effort was undertaken to improve the organization of the code.