### PR TITLE
refactor!: Remove experimental code exports in module-info

### DIFF
--- a/engine/src/main/java/module-info.java
+++ b/engine/src/main/java/module-info.java
@@ -53,11 +53,8 @@ module pro.verron.officestamper {
     opens pro.verron.officestamper.experimental to pro.verron.officestamper.test;
     exports pro.verron.officestamper.experimental to pro.verron.officestamper.test;
 
-    opens pro.verron.officestamper.core to pro.verron.officestamper.test;
-
     // TODO_LATER: remove all the following exports in next version
     exports org.wickedsource.docxstamper.el;
     exports org.wickedsource.docxstamper.util;
-    exports pro.verron.officestamper.core;
 
 }


### PR DESCRIPTION
The recent changes in 'module-info.java' involves the removal of exports and opens lines related to `pro.verron.officestamper.core`. This is part of cleanup operation of removing the experimental code references that are no longer needed.