### PR TITLE
refactor!: docxstamper classes into officestamper.core package

### DIFF
--- a/engine/src/main/java/module-info.java
+++ b/engine/src/main/java/module-info.java
@@ -54,7 +54,5 @@ module pro.verron.officestamper {
     exports pro.verron.officestamper.experimental to pro.verron.officestamper.test;
 
     // TODO_LATER: remove all the following exports in next version
-    exports org.wickedsource.docxstamper.el;
     exports org.wickedsource.docxstamper.util;
-
 }

--- a/engine/src/main/java/pro/verron/officestamper/core/CommentProcessorRegistry.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/CommentProcessorRegistry.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelParseException;
 import org.springframework.lang.NonNull;
-import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.util.RunUtil;
 import org.wickedsource.docxstamper.util.walk.BaseCoordinatesWalker;
 import pro.verron.officestamper.api.Comment;

--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
@@ -6,8 +6,6 @@ import org.springframework.expression.TypedValue;
 import org.springframework.expression.spel.SpelParserConfiguration;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.lang.NonNull;
-import org.wickedsource.docxstamper.el.ExpressionResolver;
-import org.wickedsource.docxstamper.el.StandardMethodResolver;
 import pro.verron.officestamper.api.*;
 
 import java.io.InputStream;

--- a/engine/src/main/java/pro/verron/officestamper/core/ExpressionResolver.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/ExpressionResolver.java
@@ -1,4 +1,4 @@
-package org.wickedsource.docxstamper.el;
+package pro.verron.officestamper.core;
 
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.SpelParserConfiguration;

--- a/engine/src/main/java/pro/verron/officestamper/core/PlaceholderReplacer.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/PlaceholderReplacer.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelParseException;
-import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.util.RunUtil;
 import org.wickedsource.docxstamper.util.walk.BaseCoordinatesWalker;
 import pro.verron.officestamper.api.OfficeStamperException;

--- a/engine/src/main/java/pro/verron/officestamper/core/StandardMethodExecutor.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/StandardMethodExecutor.java
@@ -1,4 +1,4 @@
-package org.wickedsource.docxstamper.el;
+package pro.verron.officestamper.core;
 
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.MethodExecutor;

--- a/engine/src/main/java/pro/verron/officestamper/core/StandardMethodResolver.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/StandardMethodResolver.java
@@ -1,4 +1,4 @@
-package org.wickedsource.docxstamper.el;
+package pro.verron.officestamper.core;
 
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.expression.EvaluationContext;


### PR DESCRIPTION
In this commit, several org.wickedsource.docxstamper.el classes were moved into the pro.verron.officestamper.core package. These include StandardMethodResolver, StandardMethodExecutor, and ExpressionResolver. This restructuring also involved updating import statements in PlaceholderReplacer, CommentProcessorRegistry, and DocxStamper classes. The org.wickedsource.docxstamper.el package was subsequently removed from module-info.java.