### PR TITLE
doc: CommentProcessorRegistry code for readability

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/api/AbstractCommentProcessor.java
+++ b/engine/src/main/java/pro/verron/officestamper/api/AbstractCommentProcessor.java
@@ -2,6 +2,7 @@ package pro.verron.officestamper.api;
 
 import org.docx4j.wml.P;
 import org.docx4j.wml.R;
+import org.springframework.lang.Nullable;
 
 import java.util.Objects;
 
@@ -78,7 +79,7 @@ public abstract class AbstractCommentProcessor
      * {@inheritDoc}
      */
     @Override
-    public void setCurrentRun(R run) {
+    public void setCurrentRun(@Nullable R run) {
         this.currentRun = run;
     }
 }

--- a/engine/src/main/java/pro/verron/officestamper/api/CommentProcessor.java
+++ b/engine/src/main/java/pro/verron/officestamper/api/CommentProcessor.java
@@ -3,6 +3,7 @@ package pro.verron.officestamper.api;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.P;
 import org.docx4j.wml.R;
+import org.springframework.lang.Nullable;
 
 /**
  * CommentProcessor is an interface that defines the methods for processing comments in a .docx template.
@@ -36,7 +37,7 @@ public interface CommentProcessor {
      *
      * @param run coordinates of the currently processed run within the template.
      */
-    void setCurrentRun(R run);
+    void setCurrentRun(@Nullable R run);
 
     /**
      * Passes the comment range wrapper that is currently being processed


### PR DESCRIPTION
Re-organized code blocks in CommentProcessorRegistry for better readability and understanding. Also, improved method parameter types with applicable annotations.