### PR TITLE
feat: move RunUtil to core package

### DIFF
--- a/engine/src/main/java/org/wickedsource/docxstamper/util/DocumentUtil.java
+++ b/engine/src/main/java/org/wickedsource/docxstamper/util/DocumentUtil.java
@@ -11,6 +11,7 @@ import org.docx4j.openpackaging.parts.relationships.RelationshipsPart;
 import org.docx4j.wml.*;
 import org.jvnet.jaxb2_commons.ppp.Child;
 import pro.verron.officestamper.api.OfficeStamperException;
+import pro.verron.officestamper.core.RunUtil;
 
 import java.util.*;
 import java.util.stream.Stream;

--- a/engine/src/main/java/org/wickedsource/docxstamper/util/IndexedRun.java
+++ b/engine/src/main/java/org/wickedsource/docxstamper/util/IndexedRun.java
@@ -1,6 +1,7 @@
 package org.wickedsource.docxstamper.util;
 
 import org.docx4j.wml.R;
+import pro.verron.officestamper.core.RunUtil;
 
 /**
  * Represents a run (i.e., a text fragment) in a paragraph. The run is indexed relative to the containing paragraph

--- a/engine/src/main/java/org/wickedsource/docxstamper/util/ParagraphUtil.java
+++ b/engine/src/main/java/org/wickedsource/docxstamper/util/ParagraphUtil.java
@@ -5,6 +5,7 @@ import org.docx4j.wml.ObjectFactory;
 import org.docx4j.wml.P;
 import org.docx4j.wml.R;
 import pro.verron.officestamper.api.OfficeStamperException;
+import pro.verron.officestamper.core.RunUtil;
 
 /**
  * Utility class for creating paragraphs.

--- a/engine/src/main/java/pro/verron/officestamper/api/StringResolver.java
+++ b/engine/src/main/java/pro/verron/officestamper/api/StringResolver.java
@@ -3,7 +3,7 @@ package pro.verron.officestamper.api;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.R;
 import org.springframework.lang.Nullable;
-import org.wickedsource.docxstamper.util.RunUtil;
+import pro.verron.officestamper.core.RunUtil;
 
 /**
  * This is an abstract class that provides a generic implementation for

--- a/engine/src/main/java/pro/verron/officestamper/core/CommentProcessorRegistry.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/CommentProcessorRegistry.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelParseException;
 import org.springframework.lang.Nullable;
-import org.wickedsource.docxstamper.util.RunUtil;
 import org.wickedsource.docxstamper.util.walk.BaseCoordinatesWalker;
 import pro.verron.officestamper.api.Comment;
 import pro.verron.officestamper.api.CommentProcessor;

--- a/engine/src/main/java/pro/verron/officestamper/core/PlaceholderReplacer.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/PlaceholderReplacer.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelParseException;
-import org.wickedsource.docxstamper.util.RunUtil;
 import org.wickedsource.docxstamper.util.walk.BaseCoordinatesWalker;
 import pro.verron.officestamper.api.OfficeStamperException;
 import pro.verron.officestamper.api.Paragraph;

--- a/engine/src/main/java/pro/verron/officestamper/core/RunUtil.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/RunUtil.java
@@ -1,4 +1,4 @@
-package org.wickedsource.docxstamper.util;
+package pro.verron.officestamper.core;
 
 import jakarta.xml.bind.JAXBElement;
 import org.docx4j.dml.wordprocessingDrawing.Inline;

--- a/engine/src/main/java/pro/verron/officestamper/core/StandardParagraph.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/StandardParagraph.java
@@ -3,7 +3,6 @@ package pro.verron.officestamper.core;
 import org.docx4j.wml.P;
 import org.docx4j.wml.R;
 import org.wickedsource.docxstamper.util.IndexedRun;
-import org.wickedsource.docxstamper.util.RunUtil;
 import pro.verron.officestamper.api.Paragraph;
 import pro.verron.officestamper.api.Placeholder;
 

--- a/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
@@ -12,7 +12,6 @@ import org.springframework.lang.Nullable;
 import org.wickedsource.docxstamper.util.DocumentUtil;
 import org.wickedsource.docxstamper.util.ObjectDeleter;
 import org.wickedsource.docxstamper.util.ParagraphUtil;
-import org.wickedsource.docxstamper.util.RunUtil;
 import org.wickedsource.docxstamper.util.walk.BaseDocumentWalker;
 import pro.verron.officestamper.api.*;
 import pro.verron.officestamper.core.*;

--- a/engine/src/main/java/pro/verron/officestamper/preset/Resolvers.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/Resolvers.java
@@ -3,11 +3,11 @@ package pro.verron.officestamper.preset;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.R;
 import org.springframework.lang.Nullable;
-import org.wickedsource.docxstamper.util.RunUtil;
 import pro.verron.officestamper.api.ObjectResolver;
 import pro.verron.officestamper.api.OfficeStamperException;
 import pro.verron.officestamper.api.Placeholder;
 import pro.verron.officestamper.api.StringResolver;
+import pro.verron.officestamper.core.RunUtil;
 
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;


### PR DESCRIPTION
The RunUtil class has been moved from the 'org.wickedsource.docxstamper.util' package to the 'pro.verron.officestamper.core' package. Relevant import adjustments in other classes have been applied to reflect this change.