### PR TITLE
feat: allow nullable object and maxWidth parameters in core

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/core/ObjectResolverRegistry.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/ObjectResolverRegistry.java
@@ -2,6 +2,7 @@ package pro.verron.officestamper.core;
 
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.R;
+import org.springframework.lang.Nullable;
 import pro.verron.officestamper.api.ObjectResolver;
 import pro.verron.officestamper.api.OfficeStamperException;
 import pro.verron.officestamper.api.Placeholder;
@@ -41,7 +42,7 @@ public final class ObjectResolverRegistry {
     public R resolve(
             WordprocessingMLPackage document,
             Placeholder placeholder,
-            Object object
+            @Nullable Object object
     ) {
         for (ObjectResolver resolver : resolvers)
             if (resolver.canResolve(object))

--- a/engine/src/main/java/pro/verron/officestamper/core/RunUtil.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/RunUtil.java
@@ -6,6 +6,7 @@ import org.docx4j.jaxb.Context;
 import org.docx4j.model.styles.StyleUtil;
 import org.docx4j.openpackaging.parts.WordprocessingML.BinaryPartAbstractImage;
 import org.docx4j.wml.*;
+import org.springframework.lang.Nullable;
 import pro.verron.officestamper.api.OfficeStamperException;
 
 import java.util.Objects;
@@ -147,7 +148,7 @@ public class RunUtil {
      * @return the run containing the image
      */
     public static R createRunWithImage(
-            Integer maxWidth,
+            @Nullable Integer maxWidth,
             BinaryPartAbstractImage abstractImage
     ) {
         // creating random ids assuming they are unique,
@@ -182,7 +183,7 @@ public class RunUtil {
     private static Inline tryCreateImageInline(
             String filenameHint,
             String altText,
-            Integer maxWidth,
+            @Nullable Integer maxWidth,
             BinaryPartAbstractImage abstractImage,
             int id1,
             int id2


### PR DESCRIPTION
Included the @Nullable annotation for the 'object' parameter in ObjectResolverRegistry and 'maxWidth' parameter in RunUtil. This allows the mentioned variables to accept null values, providing more flexibility in usage.