### PR TITLE
chore: Refactor Maven structure to multi-module project

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,12 +30,12 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - run: mvn -B -ntp verify site -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+      - run: mvn -B -ntp verify site -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -f engine/pom.xml
 
       - uses: actions/configure-pages@v4
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: 'target/site'
+          path: 'engine/target/site'
 
       - uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           cat <(echo -e "${{ secrets.GPG_SECRET_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
 
-      - run: mvn -B -ntp deploy -P gpg,!mut -Dgpg.passphrase=${{ secrets.GPG_SECRET_PASS }}
+      - run: mvn -B -ntp deploy -P gpg,!mut -Dgpg.passphrase=${{ secrets.GPG_SECRET_PASS }} -f engine/pom.xml
         env:
           MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_NAME }}
           MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASS }}

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -3,10 +3,13 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>pro.verron.office-stamper</groupId>
+    <parent>
+        <groupId>pro.verron.office-stamper</groupId>
+        <artifactId>office-stamper</artifactId>
+        <version>2.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>engine</artifactId>
-    <version>2.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
 
     <description>
         Docx-stamper is a Java template engine for docx documents.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,10 +3,13 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>pro.verron.office-stamper</groupId>
+        <artifactId>office-stamper</artifactId>
+        <version>2.0-SNAPSHOT</version>
+    </parent>
 
     <artifactId>examples</artifactId>
-    <groupId>pro.verron.office-stamper</groupId>
-    <version>0.1</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,16 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>pro.verron.office-stamper</groupId>
     <artifactId>office-stamper</artifactId>
-    <version>1.6.9</version>
+    <version>2.0-SNAPSHOT</version>
+
     <packaging>pom</packaging>
+
     <modules>
         <module>engine</module>
         <module>examples</module>
     </modules>
+
 </project>


### PR DESCRIPTION
Changes made to pom.xml files to adapt the project structure to a multimodal Maven project. The 'engine' and 'examples' modules now have 'office-stamper' as a parent. Also, updated GitHub action workflows to adapt to the changes.