### PR TITLE
feat: handle InterruptedException separately in CommentProcessorFacto…

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
@@ -969,10 +969,17 @@ public class CommentProcessorFactory {
                 var wordprocessingMLPackage = WordprocessingMLPackage.load(is);
                 thread.join();
                 return wordprocessingMLPackage;
-            } catch (Docx4JException | IOException | InterruptedException e) {
+            } catch (Docx4JException | IOException e) {
                 OfficeStamperException exception = new OfficeStamperException(e);
                 exceptionHandler.exception()
                                 .ifPresent(exception::addSuppressed);
+                throw exception;
+            } catch (InterruptedException e) {
+                OfficeStamperException exception = new OfficeStamperException(e);
+                exceptionHandler.exception()
+                                .ifPresent(e::addSuppressed);
+                Thread.currentThread()
+                      .interrupt();
                 throw exception;
             }
         }


### PR DESCRIPTION
…ry.java

Add separate catch block for handling InterruptedException. Now re-interrupts the thread and throws OfficeStamperException in case of InterruptedException. The previous version of the code handled this exception together with Docx4JException and IOException.