### PR TITLE
chore: Update versions from 2.0-SNAPSHOT to 2.0 in pom.xml files

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>pro.verron.office-stamper</groupId>
         <artifactId>office-stamper</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
 
     <artifactId>engine</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>pro.verron.office-stamper</groupId>
         <artifactId>office-stamper</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
 
     <artifactId>examples</artifactId>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>pro.verron.office-stamper</groupId>
             <artifactId>engine</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>2.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pro.verron.office-stamper</groupId>
     <artifactId>office-stamper</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Updated the version of 'office-stamper', 'engine', and 'examples' artifacts from 2.0-SNAPSHOT to the stable version 2.0. This step is part of our process preparing for a new release.