### PR TITLE
refactor: change ExpressionResolver constructor to take ExpressionParser

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/DocxStamper.java
@@ -4,6 +4,7 @@ import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.springframework.expression.TypedValue;
 import org.springframework.expression.spel.SpelParserConfiguration;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.lang.NonNull;
 import pro.verron.officestamper.api.*;
@@ -81,9 +82,10 @@ public class DocxStamper
         evaluationContext.addMethodResolver(methodResolver);
 
 
+        var expressionParser = new SpelExpressionParser(spelParserConfiguration);
         var expressionResolver = new ExpressionResolver(
                 evaluationContext,
-                spelParserConfiguration
+                expressionParser
         );
 
         var typeResolverRegistry = new ObjectResolverRegistry(resolvers);

--- a/engine/src/main/java/pro/verron/officestamper/core/ExpressionResolver.java
+++ b/engine/src/main/java/pro/verron/officestamper/core/ExpressionResolver.java
@@ -1,8 +1,6 @@
 package pro.verron.officestamper.core;
 
 import org.springframework.expression.ExpressionParser;
-import org.springframework.expression.spel.SpelParserConfiguration;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.lang.Nullable;
 import pro.verron.officestamper.api.Placeholder;
@@ -24,28 +22,27 @@ public class ExpressionResolver {
     /**
      * Creates a new ExpressionResolver with the given SpEL parser configuration.
      *
-     * @param spelParserConfiguration   the configuration for the SpEL parser.
      * @param standardEvaluationContext a {@link StandardEvaluationContext} object
      */
     public ExpressionResolver(
             StandardEvaluationContext standardEvaluationContext,
-            SpelParserConfiguration spelParserConfiguration
+            ExpressionParser expressionParser
     ) {
-        this.parser = new SpelExpressionParser(spelParserConfiguration);
+        this.parser = expressionParser;
         this.evaluationContext = standardEvaluationContext;
     }
 
     /**
      * Resolves the given expression against the provided context object.
      *
-     * @param placeholder   the expression to resolve.
-     * @param contextRoot  the context object against which to resolve the expression.
+     * @param placeholder the expression to resolve.
+     * @param contextRoot the context object against which to resolve the expression.
+     *
      * @return the resolved value of the expression.
      */
-    @Nullable
-    public Object resolve(Placeholder placeholder, Object contextRoot) {
+    @Nullable public Object resolve(Placeholder placeholder, Object contextRoot) {
         evaluationContext.setRootObject(contextRoot);
         return parser.parseExpression(placeholder.content())
-                .getValue(evaluationContext);
+                     .getValue(evaluationContext);
     }
 }


### PR DESCRIPTION
Changed the constructor of ExpressionResolver to take an instance of ExpressionParser instead of SpelParserConfiguration. The ExpressionParser object is now created in DocxStamper and passed to the ExpressionResolver construction. Removed unused SpelParserConfiguration import in ExpressionResolver. This change makes ExpressionResolver class more flexible to use either SpelExpressionParser or any other implementation of ExpressionParser.