### PR TITLE
feat(logging): change default log level to warn in simplelogger.prope…

### DIFF
--- a/engine/src/test/resources/simplelogger.properties
+++ b/engine/src/test/resources/simplelogger.properties
@@ -1,1 +1,3 @@
-org.slf4j.simpleLogger.defaultLogLevel=trace
+org.slf4j.simpleLogger.defaultLogLevel=warn
+# suppress inspection "UnusedProperty"
+org.slf4j.simpleLogger.pro.verron=trace


### PR DESCRIPTION
…rties

Update the default log level to 'warn' from 'trace'. Added 'trace' log level for 'pro.verron' in simplelogger.properties to increase verbosity for a specific logger pro.verron.