### PR TITLE
feat: Convert SECURITY documentation from .adoc to .md format since g…

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,22 +1,22 @@
-= Security Policy
+# Security Policy
 
-== Supported Versions
+## Supported Versions
 
 Currently, only the latest version of our project is being supported with security updates.
 
-|===
-| Version    | Supported
-| Latest     | :white_check_mark:
-| &lt; Older | :x:
-|===
+| Version    | Supported          |
+|------------|--------------------|
+| Latest     | :white_check_mark: |
+| &lt; Older | :x:                |
 
-== Reporting a Vulnerability
+## Reporting a Vulnerability
 
 If you have discovered a vulnerability in our project, we appreciate your help in disclosing it to us responsibly. Please avoid public disclosure of the issue until we've had a chance to address it.
 
 *Do NOT create GitHub issues for security vulnerabilities*.
 
-Instead, to ensure privacy and efficient communication, please email your findings directly to me at link:mailto:joseph@verron.pro[security@verron.pro].
+Instead, to ensure privacy and efficient communication, please email your findings directly to me at link:mailto:
+security@verron.pro[security@verron.pro].
 
 We will review your report and will communicate any updates or requests for additional information through the same
 channel. Your effort in helping us ensure the security of our project is greatly appreciated, and we will endeavor to


### PR DESCRIPTION
…ithub doesn,t recognize it

The SECURITY documentation file has been renamed from `SECURITY.adoc` to `SECURITY.md`. Aesthetic changes have been made to the "Supported Versions" section for better formatting in markdown file standard. Additionally, a minor correction was made to the contact email in the "Reporting a Vulnerability" section.