### PR TITLE
feat: Update office-stamper, engine, examples version to 2.0.1

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -3,13 +3,10 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>pro.verron.office-stamper</groupId>
-        <artifactId>office-stamper</artifactId>
-        <version>2.0</version>
-    </parent>
 
+    <groupId>pro.verron.office-stamper</groupId>
     <artifactId>engine</artifactId>
+    <version>2.0.1</version>
 
     <description>
         Docx-stamper is a Java template engine for docx documents.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,13 +3,10 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>pro.verron.office-stamper</groupId>
-        <artifactId>office-stamper</artifactId>
-        <version>2.0</version>
-    </parent>
 
+    <groupId>pro.verron.office-stamper</groupId>
     <artifactId>examples</artifactId>
+    <version>2.0.1</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pro.verron.office-stamper</groupId>
     <artifactId>office-stamper</artifactId>
-    <version>2.0</version>
+    <version>2.0.1</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
This commit bumps the version of office-stamper, engine, and examples from 2.0 to 2.0.1. Also, it removes the parent tag in engine and examples pom.xml files, and instead they have been given their specific groupId, artifactId, and version.