### PR TITLE
feat: add new maven extension for caching build

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/EXTENSIONS/1.1.0"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>org.apache.maven.extensions</groupId>
+        <artifactId>maven-build-cache-extension</artifactId>
+        <version>1.2.0</version>
+    </extension>
+</extensions>


### PR DESCRIPTION
A new file, .mvn/extensions.xml, has been created. This file incorporates a previously non-existent maven extension called 'maven-build-cache-extension' from groupId 'org.apache.maven.extensions'. Version used is 1.2.0.