### PR TITLE
refactor: move whitespace tests to separate class

### DIFF
--- a/engine/src/test/java/pro/verron/officestamper/test/DefaultTests.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/DefaultTests.java
@@ -1,6 +1,5 @@
 package pro.verron.officestamper.test;
 
-import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -12,7 +11,6 @@ import pro.verron.officestamper.preset.EvaluationContextConfigurers;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 import pro.verron.officestamper.preset.Resolvers;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
@@ -23,7 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.junit.jupiter.params.provider.Arguments.of;
 import static pro.verron.officestamper.test.Contexts.*;
-import static pro.verron.officestamper.test.TestUtils.*;
+import static pro.verron.officestamper.test.TestUtils.getImage;
+import static pro.verron.officestamper.test.TestUtils.getResource;
 
 /**
  * <p>DefaultTests class.</p>
@@ -40,11 +39,8 @@ public class DefaultTests {
      *
      * @return a {@link java.util.stream.Stream} object
      */
-    public static Stream<Arguments> tests()
-            throws Docx4JException, IOException {
+    public static Stream<Arguments> tests() {
         return Stream.of(
-                tabulations(),
-                whitespaces(),
                 ternary(),
                 repeatingRows(),
                 repeatingRowsWithLineBreak(),
@@ -87,35 +83,7 @@ public class DefaultTests {
                 controls());
     }
 
-    private static Arguments tabulations()
-            throws Docx4JException, IOException {
-        return of("Tabulation should be preserved",
-                OfficeStamperConfigurations.standard(),
-                name("Homer Simpson"),
-                makeResource("""
-                        Tab|TAB|Homer Simpson
-                        Space Homer Simpson
-                        """),
-                """
-                        Tab\tHomer Simpson
-                        Space Homer Simpson
-                        """);
-    }
 
-    private static Arguments whitespaces()
-            throws Docx4JException, IOException {
-        return of("White spaces should be preserved",
-                OfficeStamperConfigurations.standard(),
-                name("Homer Simpson"),
-                makeResource("""
-                        Tab|TAB|Homer Simpson
-                        Space Homer Simpson
-                        """),
-                """
-                        Tab\tHomer Simpson
-                        Space Homer Simpson
-                        """);
-    }
 
     private static Arguments ternary() {
         return of("Ternary operators should function",

--- a/engine/src/test/java/pro/verron/officestamper/test/WhitespaceTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/WhitespaceTest.java
@@ -1,0 +1,52 @@
+package pro.verron.officestamper.test;
+
+import org.docx4j.openpackaging.exceptions.Docx4JException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import pro.verron.officestamper.preset.OfficeStamperConfigurations;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static pro.verron.officestamper.test.Contexts.name;
+import static pro.verron.officestamper.test.TestUtils.makeResource;
+
+@DisplayName("Whitespaces manipulations")
+class WhitespaceTest {
+
+    @DisplayName("Should keep any number of spaces")
+    @CsvSource(
+            {
+                    "Homer Simpson,Homer Simpson",
+                    "Homer  Simpson,Homer  Simpson",
+                    "Homer   Simpson,Homer   Simpson"
+            })
+    @ParameterizedTest
+    void should_preserve_spaces(String in, String out)
+            throws Docx4JException, IOException {
+        var config = OfficeStamperConfigurations.standard();
+        var template = makeResource("Space ${name}");
+        var context = name(in);
+
+        var stamper = new TestDocxStamper<>(config);
+        var actual = stamper.stampAndLoadAndExtract(template, context);
+        var expected = "Space %s\n".formatted(out);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("Should keep tabulations as tabulations")
+    void should_preserve_tabulations()
+            throws IOException, Docx4JException {
+        var config = OfficeStamperConfigurations.standard();
+        var template = makeResource("Tab|TAB|${name}");
+        var context = name("Homer\tSimpson");
+
+        var stamper = new TestDocxStamper<>(config);
+        var actual = stamper.stampAndLoadAndExtract(template, context);
+        var expected = "Tab\tHomer\tSimpson\n";
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Improve test readability and organization by isolating whitespace-related tests into `WhitespaceTest.java`.