### PR TITLE
fix(pom.xml): remove unused stringifier module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
     <modules>
         <module>engine</module>
         <module>examples</module>
-        <module>stringifier</module>
     </modules>
 
 </project>


### PR DESCRIPTION
The stringifier module is no longer required and removing it streamlines the build configuration.