### PR TITLE
feat: add date-time formatting functionality

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,8 @@ image:{proj}/actions/workflows/integrate-os.yml/badge.svg[Build Status,link={pro
 
 === Features
 
-* Office-stamper can now resolve multiline placeholders (not multi paragraph, just with linebreaks).
+* Office-stamper can now format all  `java.time` objects directly from standard configuration (issue #411), see `engine/src/test/java/pro/verron/officestamper/test/DateFormatTests.java`
+* Office-stamper can now resolve multiline placeholders (not multi paragraph, just with linebreaks)(issue #422)
 * Office-stamper proven can resolve custom function inside comments expressions (issue #56)
 * Office-stamper proven can resolve displayParagraphIf inside table with repeatTableRow (issue #52)
 
@@ -111,6 +112,37 @@ As a standard, the following expressions can be used within comments:
 
 By default, an exception is thrown if a comment fails to process.
 However, successfully processed comments are wiped from the document.
+
+=== SpEL functions
+
+Office-stamper provides some function already added to the standard configuration, notably to format date & time objects.
+
+.Default activated comment processors
+[cols=">1,4"]
+|===
+| Function in .docx           | Effect on the January 1st, 2000 at the 23h34m45s 567 nano, and from zone UTC+2 in Korean Locale
+| `fdate(date)`               | ISO: 2000-01-12+02:00
+| `fdatetime(date)`           | ISO: 2000-01-12T23:34:45.000000567+02:00[UTC+02:00]
+| `ftime(date)`               | ISO: 23:34:45.000000567+02:00
+| `finstant(date)`            | ISO: 2000-01-12T21:34:45.000000567Z
+| `fbasicdate(date)`          | ISO: 20000112+0200
+| `fordinaldate(date)`        | ISO: 2000-012+02:00
+| `fweekdate(date)`           | ISO: 2000-W02-3+02:00
+| `f1123datetime(date)`       | Wed, 12 Jan 2000 23:34:45 +0200
+| `foffsetdate(date)`         | ISO: 2000-01-12+02:00
+| `foffsetdatetime(date)`     | ISO: 2000-01-12T23:34:45.000000567+02:00
+| `foffsettime(date)`         | ISO: 23:34:45.000000567+02:00
+| `fzoneddatetime(date)`      | ISO: 2000-01-12T23:34:45.000000567+02:00[UTC+02:00]
+| `flocaldate(date)`          | ISO: 2000-01-12
+| `flocaldate(date, style)`   | Style can be FULL, LONG, MEDIUM or SHORT: 2000년 1월 12일 수요일 to 00. 1. 12.
+| `flocaltime(date)`          | 23:34:45.000000567
+| `flocaltime(date, String)`  | Style can be FULL, LONG, MEDIUM or SHORT: 오후 11시 34분 45초 UTC+02:00 to 오후 11:34
+| `flocaldatetime(date)`      | 2000-01-12T23:34:45.000000567
+| `flocaldatetime(date, style)` | Style can be FULL, LONG, MEDIUM or SHORT for the same effect as flocaldate or flocaltime
+| `flocaldatetime(date, dateStyle, timeStyle)`  | Style can be FULL, LONG, MEDIUM or SHORT for the same effect as flocaldate or flocaltime
+| `fpattern(date, pattern)`            | run your own datetime pattern
+| `fpattern(date, pattern, locale)`            | run your own datetime pattern with a specified locale
+|===
 
 == Custom settings
 

--- a/RELEASE_NOTES.adoc
+++ b/RELEASE_NOTES.adoc
@@ -5,7 +5,8 @@
 
 === Features
 
-* Office-stamper can now resolve multiline placeholders (not multi paragraph, just with linebreaks).
+* Office-stamper can now format all  `java.time` objects directly from standard configuration (issue #411), see `engine/src/test/java/pro/verron/officestamper/test/DateFormatTests.java`
+* Office-stamper can now resolve multiline placeholders (not multi paragraph, just with linebreaks)(issue #422)
 * Office-stamper proven can resolve custom function inside comments expressions (issue #56)
 * Office-stamper proven can resolve displayParagraphIf inside table with repeatTableRow (issue #52)
 

--- a/engine/src/main/java/pro/verron/officestamper/preset/IStamperDateFormatter.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/IStamperDateFormatter.java
@@ -1,0 +1,47 @@
+package pro.verron.officestamper.preset;
+
+import java.time.temporal.TemporalAccessor;
+
+public interface IStamperDateFormatter {
+    String fdate(TemporalAccessor date);
+
+    String fdatetime(TemporalAccessor date);
+
+    String finstant(TemporalAccessor date);
+
+    String flocaldate(TemporalAccessor date, String style);
+
+    String fpattern(TemporalAccessor date, String pattern, String locale);
+
+    String flocaltime(TemporalAccessor date, String style);
+
+    String flocaldatetime(TemporalAccessor date, String style);
+
+    String flocaldate(TemporalAccessor date);
+
+    String fordinaldate(TemporalAccessor date);
+
+    String f1123datetime(TemporalAccessor date);
+
+    String flocaldatetime(TemporalAccessor date, String dateStyle, String timeStyle);
+
+    String fbasicdate(TemporalAccessor date);
+
+    String fweekdate(TemporalAccessor date);
+
+    String flocaldatetime(TemporalAccessor date);
+
+    String foffsetdatetime(TemporalAccessor date);
+
+    String fzoneddatetime(TemporalAccessor date);
+
+    String foffsetdate(TemporalAccessor date);
+
+    String flocaltime(TemporalAccessor date);
+
+    String foffsettime(TemporalAccessor date);
+
+    String ftime(TemporalAccessor date);
+
+    String fpattern(TemporalAccessor date, String pattern);
+}

--- a/engine/src/main/java/pro/verron/officestamper/preset/OfficeStamperConfigurations.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/OfficeStamperConfigurations.java
@@ -4,6 +4,7 @@ import pro.verron.officestamper.api.OfficeStamperConfiguration;
 import pro.verron.officestamper.api.OfficeStamperException;
 import pro.verron.officestamper.core.DocxStamperConfiguration;
 
+
 /**
  * The OfficeStamperConfigurations class provides static methods
  * to create different configurations for the OfficeStamper.
@@ -35,7 +36,9 @@ public class OfficeStamperConfigurations {
      * @return the standard OfficeStamperConfiguration
      */
     public static OfficeStamperConfiguration standard() {
-        return new DocxStamperConfiguration();
+        var configuration = new DocxStamperConfiguration();
+        configuration.exposeInterfaceToExpressionLanguage(IStamperDateFormatter.class, new StamperDateFormatter());
+        return configuration;
     }
 
     /**
@@ -50,4 +53,5 @@ public class OfficeStamperConfigurations {
         configuration.resetCommentProcessors();
         return configuration;
     }
+
 }

--- a/engine/src/main/java/pro/verron/officestamper/preset/StamperDateFormatter.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/StamperDateFormatter.java
@@ -1,0 +1,102 @@
+package pro.verron.officestamper.preset;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
+
+class StamperDateFormatter
+        implements IStamperDateFormatter {
+
+    @Override public String fdate(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_DATE.format(date);
+    }
+
+    @Override public String fdatetime(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_DATE_TIME.format(date);
+    }
+
+    @Override public String finstant(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_INSTANT.format(date);
+    }
+
+    @Override public String flocaldate(TemporalAccessor date, String style) {
+        return DateTimeFormatter.ofLocalizedDate(FormatStyle.valueOf(style))
+                                .format(date);
+    }
+
+    @Override public String fpattern(TemporalAccessor date, String pattern, String locale) {
+        return DateTimeFormatter.ofPattern(pattern, Locale.forLanguageTag(locale))
+                                .format(date);
+    }
+
+    @Override public String flocaltime(TemporalAccessor date, String style) {
+        return DateTimeFormatter.ofLocalizedTime(FormatStyle.valueOf(style))
+                                .format(date);
+    }
+
+    @Override public String flocaldatetime(TemporalAccessor date, String style) {
+        return DateTimeFormatter.ofLocalizedDateTime(FormatStyle.valueOf(style))
+                                .format(date);
+    }
+
+    @Override public String flocaldate(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_LOCAL_DATE.format(date);
+    }
+
+    @Override public String fordinaldate(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_ORDINAL_DATE.format(date);
+    }
+
+    @Override public String f1123datetime(TemporalAccessor date) {
+        return DateTimeFormatter.RFC_1123_DATE_TIME.format(date);
+    }
+
+    @Override public String flocaldatetime(TemporalAccessor date, String dateStyle, String timeStyle) {
+        return DateTimeFormatter.ofLocalizedDateTime(
+                                        FormatStyle.valueOf(dateStyle),
+                                        FormatStyle.valueOf(timeStyle))
+                                .format(date);
+    }
+
+    @Override public String fbasicdate(TemporalAccessor date) {
+        return DateTimeFormatter.BASIC_ISO_DATE.format(date);
+    }
+
+    @Override public String fweekdate(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_WEEK_DATE.format(date);
+    }
+
+    @Override public String flocaldatetime(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(date);
+    }
+
+    @Override public String foffsetdatetime(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(date);
+    }
+
+    @Override public String fzoneddatetime(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_ZONED_DATE_TIME.format(date);
+    }
+
+    @Override public String foffsetdate(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_OFFSET_DATE.format(date);
+    }
+
+    @Override public String flocaltime(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_LOCAL_TIME.format(date);
+    }
+
+    @Override public String foffsettime(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_OFFSET_TIME.format(date);
+    }
+
+    @Override public String ftime(TemporalAccessor date) {
+        return DateTimeFormatter.ISO_TIME.format(date);
+    }
+
+    @Override public String fpattern(TemporalAccessor date, String pattern) {
+        return DateTimeFormatter.ofPattern(pattern)
+                                .format(date);
+    }
+}

--- a/engine/src/test/java/pro/verron/officestamper/test/Contexts.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/Contexts.java
@@ -301,6 +301,9 @@ public class Contexts {
     public record DateContext(Date date) {
     }
 
+    public record ZonedDateContext(java.time.ZonedDateTime date) {
+    }
+
     /**
      * A static inner class representing a Spacy context.
      */

--- a/engine/src/test/java/pro/verron/officestamper/test/DateFormatTests.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/DateFormatTests.java
@@ -1,0 +1,146 @@
+package pro.verron.officestamper.test;
+
+import org.docx4j.openpackaging.exceptions.Docx4JException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static pro.verron.officestamper.preset.OfficeStamperConfigurations.standard;
+import static pro.verron.officestamper.test.TestUtils.makeResource;
+
+@DisplayName("Custom functions")
+class DateFormatTests {
+
+    @DisplayName("Should works with variables, multiline text, in comment content, inside comment, and in repetitions.")
+    @Test()
+    void features()
+            throws IOException, Docx4JException {
+        new Date();
+        var config = standard();
+        Locale.setDefault(Locale.KOREA);
+        var template = makeResource("""
+                ISO Date: ${fdate(date)}
+                ISO Datetime: ${fdatetime(date)}
+                ISO Time: ${ftime(date)}
+                
+                ISO Instant: ${finstant(date)}
+                ISO Basic Date: ${fbasicdate(date)}
+                ISO Ordinal Date: ${fordinaldate(date)}
+                ISO Week Date: ${fweekdate(date)}
+                RFC 1123 Datetime: ${f1123datetime(date)}
+                
+                ISO Offset Date: ${foffsetdate(date)}
+                ISO Offset Datetime: ${foffsetdatetime(date)}
+                ISO Offset Time: ${foffsettime(date)}
+                
+                ISO Zoned Datetime: ${fzoneddatetime(date)}
+                
+                ISO Localized Date (DEFAULT): ${flocaldate(date)}
+                ISO Localized Date (FULL): ${flocaldate(date, "FULL")}
+                ISO Localized Date (LONG):${flocaldate(date, "LONG")}
+                ISO Localized Date (MEDIUM):${flocaldate(date, "MEDIUM")}
+                ISO Localized Date (SHORT):${flocaldate(date, "SHORT")}
+                
+                ISO Localized Time (DEFAULT): ${flocaltime(date)}
+                ISO Localized Time (FULL): ${flocaltime(date, "FULL")}
+                ISO Localized Time (LONG): ${flocaltime(date, "LONG")}
+                ISO Localized Time (MEDIUM): ${flocaltime(date, "MEDIUM")}
+                ISO Localized Time (SHORT): ${flocaltime(date, "SHORT")}
+                
+                Julian Calendar (Default Locale): ${fpattern(date, "GyyyyDDD")}
+                Julian Calendar (French Locale): ${fpattern(date, "GyyyyDDD", "FR")}
+                Julian Calendar (English Locale): ${fpattern(date, "GyyyyDDD", "EN")}
+                Julian Calendar (Chinese Locale): ${fpattern(date, "GyyyyDDD", "ZH")}
+                
+                ISO Localized Datetime (DEFAULT): ${flocaldatetime(date)}
+                ISO Localized Datetime (FULL): ${flocaldatetime(date, "FULL")}
+                ISO Localized Datetime (LONG): ${flocaldatetime(date, "LONG")}
+                ISO Localized Datetime (MEDIUM): ${flocaldatetime(date, "MEDIUM")}
+                ISO Localized Datetime (SHORT): ${flocaldatetime(date, "SHORT")}
+                
+                ISO Localized Datetime (FULL, FULL): ${flocaldatetime(date, "FULL", "FULL")}
+                ISO Localized Datetime (FULL, LONG): ${flocaldatetime(date, "FULL", "LONG")}
+                ISO Localized Datetime (FULL, MEDIUM): ${flocaldatetime(date, "FULL", "MEDIUM")}
+                ISO Localized Datetime (FULL, SHORT): ${flocaldatetime(date, "FULL", "SHORT")}
+                ISO Localized Datetime (LONG, FULL): ${flocaldatetime(date, "LONG", "FULL")}
+                ISO Localized Datetime (LONG, LONG): ${flocaldatetime(date, "LONG", "LONG")}
+                ISO Localized Datetime (LONG, MEDIUM): ${flocaldatetime(date, "LONG", "MEDIUM")}
+                ISO Localized Datetime (LONG, SHORT): ${flocaldatetime(date, "LONG", "SHORT")}
+                ISO Localized Datetime (MEDIUM, FULL): ${flocaldatetime(date, "MEDIUM", "FULL")}
+                ISO Localized Datetime (MEDIUM, LONG): ${flocaldatetime(date, "MEDIUM", "LONG")}
+                ISO Localized Datetime (MEDIUM, MEDIUM): ${flocaldatetime(date, "MEDIUM", "MEDIUM")}
+                ISO Localized Datetime (MEDIUM, SHORT): ${flocaldatetime(date, "MEDIUM", "SHORT")}
+                ISO Localized Datetime (SHORT, FULL): ${flocaldatetime(date, "SHORT", "FULL")}
+                ISO Localized Datetime (SHORT, LONG): ${flocaldatetime(date, "SHORT", "LONG")}
+                ISO Localized Datetime (SHORT, MEDIUM): ${flocaldatetime(date, "SHORT", "MEDIUM")}
+                ISO Localized Datetime (SHORT, SHORT): ${flocaldatetime(date, "SHORT", "SHORT")}
+                """);
+        var context = new Contexts.ZonedDateContext(ZonedDateTime.of(2000, 1, 12, 23, 34, 45, 567, ZoneId.of("UTC+2")));
+        var stamper = new TestDocxStamper<>(config);
+        var expected = """
+                ISO Date: 2000-01-12+02:00
+                ISO Datetime: 2000-01-12T23:34:45.000000567+02:00[UTC+02:00]
+                ISO Time: 23:34:45.000000567+02:00
+                
+                ISO Instant: 2000-01-12T21:34:45.000000567Z
+                ISO Basic Date: 20000112+0200
+                ISO Ordinal Date: 2000-012+02:00
+                ISO Week Date: 2000-W02-3+02:00
+                RFC 1123 Datetime: Wed, 12 Jan 2000 23:34:45 +0200
+                
+                ISO Offset Date: 2000-01-12+02:00
+                ISO Offset Datetime: 2000-01-12T23:34:45.000000567+02:00
+                ISO Offset Time: 23:34:45.000000567+02:00
+                
+                ISO Zoned Datetime: 2000-01-12T23:34:45.000000567+02:00[UTC+02:00]
+                
+                ISO Localized Date (DEFAULT): 2000-01-12
+                ISO Localized Date (FULL): 2000년 1월 12일 수요일
+                ISO Localized Date (LONG):2000년 1월 12일
+                ISO Localized Date (MEDIUM):2000. 1. 12.
+                ISO Localized Date (SHORT):00. 1. 12.
+                
+                ISO Localized Time (DEFAULT): 23:34:45.000000567
+                ISO Localized Time (FULL): 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Time (LONG): 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Time (MEDIUM): 오후 11:34:45
+                ISO Localized Time (SHORT): 오후 11:34
+                
+                Julian Calendar (Default Locale): 서기2000012
+                Julian Calendar (French Locale): ap. J.-C.2000012
+                Julian Calendar (English Locale): AD2000012
+                Julian Calendar (Chinese Locale): 公元2000012
+                
+                ISO Localized Datetime (DEFAULT): 2000-01-12T23:34:45.000000567
+                ISO Localized Datetime (FULL): 2000년 1월 12일 수요일 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (LONG): 2000년 1월 12일 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (MEDIUM): 2000. 1. 12. 오후 11:34:45
+                ISO Localized Datetime (SHORT): 00. 1. 12. 오후 11:34
+                
+                ISO Localized Datetime (FULL, FULL): 2000년 1월 12일 수요일 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (FULL, LONG): 2000년 1월 12일 수요일 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (FULL, MEDIUM): 2000년 1월 12일 수요일 오후 11:34:45
+                ISO Localized Datetime (FULL, SHORT): 2000년 1월 12일 수요일 오후 11:34
+                ISO Localized Datetime (LONG, FULL): 2000년 1월 12일 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (LONG, LONG): 2000년 1월 12일 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (LONG, MEDIUM): 2000년 1월 12일 오후 11:34:45
+                ISO Localized Datetime (LONG, SHORT): 2000년 1월 12일 오후 11:34
+                ISO Localized Datetime (MEDIUM, FULL): 2000. 1. 12. 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (MEDIUM, LONG): 2000. 1. 12. 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (MEDIUM, MEDIUM): 2000. 1. 12. 오후 11:34:45
+                ISO Localized Datetime (MEDIUM, SHORT): 2000. 1. 12. 오후 11:34
+                ISO Localized Datetime (SHORT, FULL): 00. 1. 12. 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (SHORT, LONG): 00. 1. 12. 오후 11시 34분 45초 UTC+02:00
+                ISO Localized Datetime (SHORT, MEDIUM): 00. 1. 12. 오후 11:34:45
+                ISO Localized Datetime (SHORT, SHORT): 00. 1. 12. 오후 11:34
+                """;
+        var actual = stamper.stampAndLoadAndExtract(template, context);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Introduce IStamperDateFormatter interface and StamperDateFormatter implementation to format java.time objects. Update README and release notes to document new feature.

This enhancement addresses issue #411, allowing Office-stamper to format date and time objects directly from standard configuration.