### PR TITLE
Rename TestBug52 and add tests for issues 52 and 64

### DIFF
--- a/engine/src/test/java/pro/verron/officestamper/test/RegressionTests.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/RegressionTests.java
@@ -1,9 +1,13 @@
 package pro.verron.officestamper.test;
 
+import org.docx4j.openpackaging.exceptions.Docx4JException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import pro.verron.officestamper.api.OfficeStamperConfiguration;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -16,11 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static pro.verron.officestamper.preset.OfficeStamperConfigurations.standardWithPreprocessing;
 
-class TestBug52 {
+class RegressionTests {
 
     private static final Path TEMPLATE_52 = Path.of("#52.docx");
 
-    public static Stream<Arguments> source() {
+    public static Stream<Arguments> source52() {
         return Stream.of(arguments(Conditions.values(), ""),
                 arguments(Conditions.values(true), "Start\nHello, World!\nEnd\n"),
                 arguments(Conditions.values(false), "Start\nEnd\n"),
@@ -30,21 +34,57 @@ class TestBug52 {
                 arguments(Conditions.values(false, false), "Start\nEnd\nStart\nEnd\n"));
     }
 
-    @MethodSource("source")
+    @Test
+    void test64()
+            throws IOException, Docx4JException {
+        var configuration = givenConfiguration();
+        configuration.exposeInterfaceToExpressionLanguage(TestFunction.class, new TestFunction.TestFunctionImpl());
+        var stamper = givenStamper(configuration);
+        var template = givenTemplate("${test()}");
+        var context = givenContext();
+        var actual = stamper.stampAndLoadAndExtract(template, context);
+        assertEquals("\n", actual);
+    }
+
+    private static OfficeStamperConfiguration givenConfiguration() {
+        return standardWithPreprocessing();
+    }
+
+    private static TestDocxStamper<Object> givenStamper(OfficeStamperConfiguration configuration) {
+        return new TestDocxStamper<>(configuration);
+    }
+
+    private static InputStream givenTemplate(String str)
+            throws Docx4JException, IOException {
+        return TestUtils.makeResource(str);
+    }
+
+    private static Object givenContext() {
+        return new Object();
+    }
+
+    @MethodSource("source52")
     @ParameterizedTest
-    void test(Conditions conditions, String expected) {
-        var stamper = givenStamper();
-        var template = givenTemplate();
+    void test52(Conditions conditions, String expected) {
+        var stamper = givenStamper(givenConfiguration());
+        var template = givenTemplate(TEMPLATE_52);
         var actual = stamper.stampAndLoadAndExtract(template, conditions);
         assertEquals(expected, actual);
     }
 
-    private static TestDocxStamper<Object> givenStamper() {
-        return new TestDocxStamper<>(standardWithPreprocessing());
+    private static InputStream givenTemplate(Path path) {
+        return TestUtils.getResource(path);
     }
 
-    private static InputStream givenTemplate() {
-        return TestUtils.getResource(TEMPLATE_52);
+    public interface TestFunction {
+        void test();
+
+        class TestFunctionImpl
+                implements TestFunction {
+            @Override public void test() {
+                System.out.println("Test");
+            }
+        }
     }
 
     record Condition(boolean condition) {}


### PR DESCRIPTION
Renamed class TestBug52 to RegressionTests for clarity. Added a new test method for issue 64 focusing on failures when calling a function defined within its own interface. Updated existing test method for issue 52 to accommodate the renaming and new organizational structure.